### PR TITLE
feat: remove hidden pages from sitemap

### DIFF
--- a/app/config/seo.json
+++ b/app/config/seo.json
@@ -81,14 +81,14 @@
     "description": "Explore the beauty, culture, and hospitality of {{lguName}}. Discover local attractions and vibrant festivals.",
     "ogType": "website",
     "twitterCard": "summary",
-    "hidden": false
+    "hidden": true
   },
   "news-index": {
     "titleFragment": "News & Announcements",
     "description": "Stay updated with the latest news, announcements, and press releases from the {{lguTypeLabel}} of {{lguName}}.",
     "ogType": "website",
     "twitterCard": "summary",
-    "hidden": false
+    "hidden": true
   },
   "legislative-ordinance-framework": {
     "titleFragment": "Ordinance Framework",
@@ -137,7 +137,7 @@
     "description": "Read the latest news and announcements from the {{lguTypeLabel}} of {{lguName}}.",
     "ogType": "article",
     "twitterCard": "summary_large_image",
-    "hidden": false
+    "hidden": true
   },
   "services-category": {
     "titleFragment": "Service Category",

--- a/app/pages/sitemap.vue
+++ b/app/pages/sitemap.vue
@@ -27,7 +27,7 @@ const sections = computed<SitemapSection[]>(() => [
       { href: '/legislative', label: 'Legislative', hidden: true },
       { href: '/budget', label: 'Transparency', hidden: true },
       { href: '/contact', label: 'Contact' },
-      { href: '/news', label: 'News' },
+      { href: '/news', label: 'News', hidden: true },
       { href: '/faq', label: 'FAQ' },
       { href: '/accessibility', label: 'Accessibility' },
     ],
@@ -59,44 +59,54 @@ const sections = computed<SitemapSection[]>(() => [
       {
         href: '/service-details/civil-registrar',
         label: 'Local Civil Registrar',
+        hidden: true,
       },
       {
         href: '/service-details/municipal-treasurer',
         label: 'Treasurer\'s Office',
+        hidden: true,
       },
       {
         href: '/service-details/municipal-assessor',
         label: 'Assessor\'s Office',
+        hidden: true,
       },
-      { href: '/service-details/municipal-budget', label: 'Budget Office' },
+      { href: '/service-details/municipal-budget', label: 'Budget Office', hidden: true },
       {
         href: '/service-details/municipal-accounting',
         label: 'Accounting Office',
+        hidden: true,
       },
       {
         href: '/service-details/municipal-engineering',
         label: 'Engineering Office',
+        hidden: true,
       },
       {
         href: '/service-details/municipal-planning',
         label: 'Planning Office',
+        hidden: true,
       },
       {
         href: '/service-details/municipal-agriculture',
         label: 'Agriculture Office',
+        hidden: true,
       },
-      { href: '/service-details/mswdo-services', label: 'MSWDO' },
+      { href: '/service-details/mswdo-services', label: 'MSWDO', hidden: true },
       {
         href: '/service-details/business-permits-licensing',
         label: 'BPLS Office',
+        hidden: true,
       },
       {
         href: '/service-details/general-services',
         label: 'General Services',
+        hidden: true,
       },
       {
         href: '/service-details/human-resource-management',
         label: 'HR Management',
+        hidden: true,
       },
     ],
   },
@@ -109,10 +119,12 @@ const sections = computed<SitemapSection[]>(() => [
       {
         href: '/legislative/ordinance-framework',
         label: 'Ordinance Framework',
+        hidden: true,
       },
       {
         href: '/legislative/resolution-framework',
         label: 'Resolution Framework',
+        hidden: true,
       },
     ],
   },
@@ -164,7 +176,7 @@ const sections = computed<SitemapSection[]>(() => [
       <div class="container mx-auto px-4">
         <div class="space-y-8">
           <UiCard
-            v-for="section in sections"
+            v-for="section in sections.filter(section => section.links.some(link => !link.hidden))"
             :key="section.title"
             padding="p-0"
             class="overflow-hidden"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,6 +7,25 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   sitemap: {
     zeroRuntime: true,
+    exclude: [
+      '/budget',
+      '/history',
+      '/legislative/**',
+      '/news',
+      '/services/business',
+      '/services/social-services',
+      '/services/health',
+      '/services/tax-payments',
+      '/services/agriculture',
+      '/services/infrastructure',
+      '/services/education',
+      '/services/environment',
+      '/services/public-safety',
+      '/tourism',
+    ],
+    urls: [
+      '/services/certificates',
+    ],
   },
   ssr: true,
   ogImage: {


### PR DESCRIPTION
## Description

Restricted sitemap generation and visibility by excluding hidden and specific internal pages from sitemap.xml and the visual sitemap page. This ensures that only relevant, public-facing content is indexed by search engines and displayed to users.

Fixes #22 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Verified sitemap filtering through manual inspection of the generated XML and page components.

- [x] Verified sitemap.xml to confirm excluded routes are no longer listed.
- [x] Verified /sitemap page to confirm hidden categories and empty sections are removed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
