### PR TITLE
feat: add which services is open on fridays

### DIFF
--- a/app/config/faq.json
+++ b/app/config/faq.json
@@ -9,7 +9,7 @@
         {
           "id": "office-hours",
           "question": "What are the office hours of the {{hallName}}?",
-          "answer": "The {{hallName}} is generally open Monday to Thursday, 8:00 AM to 7:00 PM, with a lunch break from 12:00 PM to 1:00 PM. We are closed on weekends and national/local holidays. However, essential services and specific offices (City Health Office, Traffic Management Office, City Engineering Office, City Agriculture Office, and all emergency response/disaster management teams) remain operational on Fridays under regular or shifting schedules."
+          "answer": "The {{hallName}} is generally open Monday to Thursday, 8:00 AM to 7:00 PM. We are closed on weekends and national/local holidays. However, essential services and specific offices (City Health Office, Traffic Management Office, City Engineering Office, City Agriculture Office, and all emergency response/disaster management teams) remain operational on Fridays under regular or shifting schedules."
         },
         {
           "id": "contact-office",

--- a/app/config/faq.json
+++ b/app/config/faq.json
@@ -9,7 +9,7 @@
         {
           "id": "office-hours",
           "question": "What are the office hours of the {{hallName}}?",
-          "answer": "The {{hallName}} is open Monday to Thursday, 8:00 AM to 7:00 PM, with a lunch break from 12:00 PM to 1:00 PM. We are closed on Fridays, weekends and national/local holidays. Essential services remain operational on regular operations."
+          "answer": "The {{hallName}} is generally open Monday to Thursday, 8:00 AM to 7:00 PM, with a lunch break from 12:00 PM to 1:00 PM. We are closed on weekends and national/local holidays. However, essential services and specific offices (City Health Office, Traffic Management Office, City Engineering Office, City Agriculture Office, and all emergency response/disaster management teams) remain operational on Fridays under regular or shifting schedules."
         },
         {
           "id": "contact-office",

--- a/app/pages/contact/index.vue
+++ b/app/pages/contact/index.vue
@@ -5,7 +5,6 @@ const { site, hotlines, formatPhoneLink } = useConfig()
 const officeHours = [
   { day: 'Monday - Thursday', time: '8:00 AM - 7:00 PM', status: 'Open', icon: 'bi-check-circle-fill', textClass: 'text-green-600', bgClass: 'bg-green-50' },
   { day: 'Friday', time: '8:00 AM - 5:00 PM (Essential Services: CHO, Traffic, Emergency Teams)', status: 'Partial', icon: 'bi-info-circle-fill', textClass: 'text-blue-600', bgClass: 'bg-blue-50' },
-  { day: 'Lunch Break', time: '12:00 PM - 1:00 PM', status: 'Break', icon: 'bi-pause-circle-fill', textClass: 'text-yellow-600', bgClass: 'bg-yellow-50' },
   { day: 'Saturday & Sunday', time: 'Closed', status: 'Closed', icon: 'bi-x-circle-fill', textClass: 'text-red-600', bgClass: 'bg-red-50' },
   { day: 'National & Local Holidays', time: 'Closed', status: 'Closed', icon: 'bi-x-circle-fill', textClass: 'text-red-600', bgClass: 'bg-red-50' },
 ]

--- a/app/pages/contact/index.vue
+++ b/app/pages/contact/index.vue
@@ -4,7 +4,7 @@ import { useConfig } from '@/composables/useConfig'
 const { site, hotlines, formatPhoneLink } = useConfig()
 const officeHours = [
   { day: 'Monday - Thursday', time: '8:00 AM - 7:00 PM', status: 'Open', icon: 'bi-check-circle-fill', textClass: 'text-green-600', bgClass: 'bg-green-50' },
-  { day: 'Friday', time: 'Essential Services Only', status: 'Partial', icon: 'bi-info-circle-fill', textClass: 'text-blue-600', bgClass: 'bg-blue-50' },
+  { day: 'Friday', time: '8:00 AM - 5:00 PM (Essential Services: CHO, Traffic, Emergency Teams)', status: 'Partial', icon: 'bi-info-circle-fill', textClass: 'text-blue-600', bgClass: 'bg-blue-50' },
   { day: 'Lunch Break', time: '12:00 PM - 1:00 PM', status: 'Break', icon: 'bi-pause-circle-fill', textClass: 'text-yellow-600', bgClass: 'bg-yellow-50' },
   { day: 'Saturday & Sunday', time: 'Closed', status: 'Closed', icon: 'bi-x-circle-fill', textClass: 'text-red-600', bgClass: 'bg-red-50' },
   { day: 'National & Local Holidays', time: 'Closed', status: 'Closed', icon: 'bi-x-circle-fill', textClass: 'text-red-600', bgClass: 'bg-red-50' },


### PR DESCRIPTION
## Description

This PR updates the displayed office hours to provide residents with more accurate and clearer information regarding the LGU's operating schedule. 

Specifically, this update:
- **Elaborates Friday operations**: Updates the Contact page and General FAQ to explicitly list which essential services remain operational on Fridays (City Health Office, Traffic Management Office, City Engineering Office, City Agriculture Office, and emergency teams), along with their specific hours (`8:00 AM - 5:00 PM`).
- **Removes lunch break**: Removes the explicit `12:00 PM - 1:00 PM` lunch break from both the `officeHours` array in `contact/index.vue` and the FAQ answer in `faq.json` to reflect continuous `8:00 AM - 7:00 PM` operations (Mon-Thu).

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Verified the Contact page (`/contact`) UI renders the updated Friday schedule and exempted offices text correctly.
- [x] Verified the Contact page (`/contact`) no longer displays a "Lunch Break" row.
- [x] Verified the General FAQ section renders the expanded Friday operational hours text for the specific departments.
- [x] Verified the General FAQ section no longer mentions a lunch break closure.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
