### PR TITLE
fix: update hardcoded year and income data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Friday opening information added to relevant LGU services
 
 ### Changed
+- Updated hardcoded year and income data in city statistics
 - Updated office hours to remove lunch breaks and clarify continuous operation
 - Cleaned up sitemap to exclude hidden and draft pages from public search indexing
 - Barangay Chairmen have been updated to the latest as of Q1 2026

--- a/app/components/statistics/CityFinance.vue
+++ b/app/components/statistics/CityFinance.vue
@@ -15,7 +15,7 @@ defineProps<{
           City Income
         </h2>
         <p class="text-gray-500">
-          Financial standing for fiscal year 2023
+          Financial standing for fiscal year {{ statisticsDetailed.financialData?.year }}
         </p>
       </div>
 
@@ -38,7 +38,7 @@ defineProps<{
             <span>NTA Share</span>
           </div>
           <div class="text-3xl font-bold text-gray-900 mb-1">
-            {{ statisticsDetailed.financialData?.iraShare }}
+            {{ statisticsDetailed.financialData?.ntaShare }}
           </div>
           <div class="text-sm text-gray-500">
             National Tax Allotment
@@ -50,7 +50,7 @@ defineProps<{
             <span>NTA Dependency</span>
           </div>
           <div class="text-3xl font-bold text-gray-900 mb-1">
-            {{ statisticsDetailed.financialData?.iraDependency }}
+            {{ statisticsDetailed.financialData?.ntaDependency }}
           </div>
           <div class="text-sm text-gray-500">
             National Tax Share
@@ -65,9 +65,9 @@ defineProps<{
         <div class="h-6 bg-gray-100 rounded-full overflow-hidden flex">
           <div
             class="bg-primary-600 h-full flex items-center justify-center text-white text-xs font-medium"
-            :style="{ width: statisticsDetailed.financialData?.iraDependency }"
+            :style="{ width: statisticsDetailed.financialData?.ntaDependency }"
           >
-            NTA {{ statisticsDetailed.financialData?.iraDependency }}
+            NTA {{ statisticsDetailed.financialData?.ntaDependency }}
           </div>
           <div
             class="bg-green-500 h-full flex items-center justify-center text-white text-xs font-medium"
@@ -99,7 +99,7 @@ defineProps<{
         >
           {{ statisticsDetailed.financialData?.source }}
         </a>
-        – {{ statisticsDetailed.financialData?.year }} SRE Data
+        – {{ statisticsDetailed.financialData?.year }} Annual Regular Income (ARI) and Dependencies
       </p>
     </div>
   </section>

--- a/app/config/statistics-detailed.json
+++ b/app/config/statistics-detailed.json
@@ -165,12 +165,12 @@
   ],
   "financialData": {
     "annualIncome": "₱3.89B",
-    "annualIncomeDetailed": "₱3,894,064,737.00",
-    "iraShare": "₱1.74B",
-    "iraDependency": "44.72%",
-    "localSourcesPercentage": "55.28%",
+    "annualIncomeDetailed": "₱3,894,064,737.40",
+    "ntaShare": "₱1.74B",
+    "ntaDependency": "44.60%",
+    "localSourcesPercentage": "55.10%",
     "source": "Bureau of Local Government Finance (BLGF)",
-    "sourceUrl": "https://blgf.gov.ph/",
+    "sourceUrl": "https://blgf.gov.ph/lgu-fiscal-data/",
     "year": 2024
   },
   "populationGrowth": {

--- a/app/types/config.ts
+++ b/app/types/config.ts
@@ -183,8 +183,8 @@ export interface StatisticsDetailedConfig {
   financialData: {
     annualIncome: string
     annualIncomeDetailed: string
-    iraShare: string
-    iraDependency: string
+    ntaShare: string
+    ntaDependency: string
     localSourcesPercentage: string
     sourceUrl: string
     source: string


### PR DESCRIPTION
## Description

This PR addresses the mismatch in City Income statistics by updating hardcoded years and transitioning from IRA (Internal Revenue Allotment) terminology to the updated NTA (National Tax Allotment) and ARI (Annual Regular Income) terminology.

Key changes include:
- **Dynamic Year Display**: Replaced the hardcoded fiscal year "2023" in [CityFinance.vue] with a dynamic reference to the configuration data.
- **Terminology Update**: Renamed `iraShare` and `iraDependency` to `ntaShare` and `ntaDependency` across the component, type definitions, and configuration files to align with current National Tax Allotment standards.
- **Data Accuracy**: Updated the annual income figures, NTA dependency percentages, and the BLGF source URL in [statistics-detailed.json] to reflect the latest 2024 SRE/ARI data.
- **UI Refinement**: Updated the data source footer to specifically mention "Annual Regular Income (ARI) and Dependencies".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Verified that the "City Income" section now dynamically displays "Fiscal Year 2024".
- [x] Verified that NTA Share and NTA Dependency values are correctly rendered using the new property names.
- [x] Checked that the footer source link and text correctly reflect the updated ARI/Dependency information.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
