### PR TITLE
fix: remove outdated component and use the right component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fixed hydration mismatch issue in service details layout
 - Prevented empty "Unreleased" section (and other empty versions or sections) from being rendered on the Changelog page
 
 ### Infrastructure

--- a/app/pages/service-details/[slug].vue
+++ b/app/pages/service-details/[slug].vue
@@ -28,13 +28,22 @@ function toggleFaq(index: number) {
       ]"
     />
 
-    <ServicesPageHeader
+    <UiPageHero
       :badge-icon="service.badgeIcon"
       :badge-text="service.badgeText"
       :title="service.fullTitle"
       :description="service.description"
-      search-placeholder="Search other services..."
-    />
+    >
+      <div class="max-w-xl mx-auto mt-8">
+        <div class="relative flex items-center">
+          <i class="bi bi-search absolute left-4 text-gray-400 z-10 pointer-events-none" />
+          <ServicesSearch
+            placeholder="Search services (e.g., birth certificate, marriage certificate)"
+            class="w-full [&_input]:pl-12 [&_input]:pr-4 [&_input]:py-4 [&_input]:rounded-xl [&_input]:text-base [&_input]:border-0 [&_input]:shadow-lg"
+          />
+        </div>
+      </div>
+    </UiPageHero>
 
     <!-- Quick Stats -->
     <section class="py-8 bg-gray-50">


### PR DESCRIPTION
## Description

Resolves hydration mismatch issues on the Service Details pages caused by the `ServicesPageHeader` component. Replaced the generic component with `UiPageHero` and embedded the `ServicesSearch` correctly.

Fixes #61

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Verified Service Details page rendering locally on both server and client side without throwing hydration errors.
- [x] Confirmed that `ServicesSearch` component works as expected within the new `UiPageHero` wrapper.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have added my changes to the `Unreleased` section of `CHANGELOG.md`
