### PR TITLE
Feat/update site name displayed in search engine results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Nuxt Schema Org to change the site name in search results
+
 ### Fixed
 - Fixed hydration mismatch issue in service details layout
 - Prevented empty "Unreleased" section (and other empty versions or sections) from being rendered on the Changelog page

--- a/app/app.vue
+++ b/app/app.vue
@@ -7,9 +7,12 @@ defineOgImage('DefaultBranding.takumi', {
 useSchemaOrg([
   defineWebPage({
     name: config.siteBrandName.value,
+    url: config.getOpenGraphUrl(),
   }),
   defineWebSite({
     name: config.siteBrandName.value,
+    url: config.getOpenGraphUrl(),
+
   }),
 ])
 </script>

--- a/app/app.vue
+++ b/app/app.vue
@@ -4,6 +4,14 @@ const config = useConfig()
 defineOgImage('DefaultBranding.takumi', {
   title: config.siteBrandName.value,
 })
+useSchemaOrg([
+  defineWebPage({
+    name: config.siteBrandName.value,
+  }),
+  defineWebSite({
+    name: config.siteBrandName.value,
+  }),
+])
 </script>
 
 <template>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "leaflet": "^1.9.4",
     "lucide-vue-next": "^1.0.0",
     "nuxt": "^4.4.2",
-    "nuxt-schema-org": "^6.0.4",
     "pinia": "^3.0.4",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "eslint-plugin-format": "^2.0.1",
     "happy-dom": "^20.8.9",
     "husky": "^9.1.7",
-    "nuxt-og-image": "^6.3.2",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.2",
     "vitest": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "leaflet": "^1.9.4",
     "lucide-vue-next": "^1.0.0",
     "nuxt": "^4.4.2",
+    "nuxt-schema-org": "^6.0.4",
     "pinia": "^3.0.4",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       nuxt:
         specifier: ^4.4.2
         version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.9.2)(@parcel/watcher@2.5.6)(@types/node@25.5.2)(@vue/compiler-sfc@3.5.32)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@10.2.0(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(yaml@2.8.3)
+      nuxt-schema-org:
+        specifier: ^6.0.4
+        version: 6.0.4(e098146515632dac6fdbfe1d9b38d0fa)
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3))
@@ -9265,8 +9268,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,6 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
-      nuxt-og-image:
-        specifier: ^6.3.2
-        version: 6.3.2(01b4ed352590eb7c9d54aca1c482d203)
       postcss:
         specifier: ^8.5.8
         version: 8.5.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       nuxt:
         specifier: ^4.4.2
         version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.8.1)(@emnapi/runtime@1.9.2)(@parcel/watcher@2.5.6)(@types/node@25.5.2)(@vue/compiler-sfc@3.5.32)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@10.2.0(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(yaml@2.8.3)
-      nuxt-schema-org:
-        specifier: ^6.0.4
-        version: 6.0.4(e098146515632dac6fdbfe1d9b38d0fa)
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3))


### PR DESCRIPTION
## Description

By using the Nuxt Schema Org module by Nuxt SEO, this feature gets to improve on the existing SEO config defaults that sets the site name of the website especially as it is displayed in the Search Engine results. By using the module's `useSchemaOrg` function in the base `app.vue`, the improvement gets to set the site name with the `siteBrandName` found in the `config.json`.

Fixes #81

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Verified Nuxt Schema Org values via Nuxt Dev Tools
- [x] Inspected Page Source to see raw html contains `<script>` tag with `type="application/ld+json"` prop

<img width="1593" height="441" alt="image" src="https://github.com/user-attachments/assets/9ab61f52-8136-4cf8-8472-680edcd4d92e" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have added my changes to the `Unreleased` section of `CHANGELOG.md`
