### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners
+* @jmacj @Martin-Enghoy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevented empty "Unreleased" section (and other empty versions or sections) from being rendered on the Changelog page
 
 ### Infrastructure
+- **Added**: `CODEOWNERS` file to define repository maintainers
 - **Added**: `--tags` to `git fetch` in `cd.yml` to support `git describe`
 - **Removed**: Redundant tag-based deployment trigger from `cd.yml`
 


### PR DESCRIPTION
## Description

This PR adds a `CODEOWNERS` file to the repository to define default maintainers for all files, specifically `@jmacj` and `@Martin-Enghoy`. This ensures that they are automatically requested for review on new pull requests. Additionally, the `CHANGELOG.md` has been updated to reflect this infrastructure change.

Fixes # (N/A - Chore)

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Manually verified the existence and content of `.github/CODEOWNERS`.
- [x] Verified the placement of the entry in `CHANGELOG.md`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added my changes to the `Unreleased` section of `CHANGELOG.md`

