### PR TITLE
feat/add occupational mayors permit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nuxt Schema Org to change the site name in search results
 - Added new "Issuance of Special Permit" service to the Business, Trade & Investment category with full Citizen's Charter details
 - Added new "Occupational Mayor's Permit (Regular)" service to the Business, Trade & Investment category with full Citizen's Charter details
+- Added new "Occupational Mayor's Permit (First Time Job Seeker)" service highlighting free assistance under R.A. 11261
 - Launched "Business, Trade & Investment" category with detailed guides for New and Renewal Business Permits, featuring online application support and official Citizen's Charter attribution
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Nuxt Schema Org to change the site name in search results
 - Added new "Issuance of Special Permit" service to the Business, Trade & Investment category with full Citizen's Charter details
+- Added new "Occupational Mayor's Permit (Regular)" service to the Business, Trade & Investment category with full Citizen's Charter details
 - Launched "Business, Trade & Investment" category with detailed guides for New and Renewal Business Permits, featuring online application support and official Citizen's Charter attribution
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new "Issuance of Special Permit" service to the Business, Trade & Investment category with full Citizen's Charter details
 - Added new "Occupational Mayor's Permit (Regular)" service to the Business, Trade & Investment category with full Citizen's Charter details
 - Added new "Occupational Mayor's Permit (First Time Job Seeker)" service highlighting free assistance under R.A. 11261
+- Added new "Certificates on Status of Business" service for verifying registered business entity status via the BPLO
 - Launched "Business, Trade & Investment" category with detailed guides for New and Renewal Business Permits, featuring online application support and official Citizen's Charter attribution
 
 ### Changed

--- a/app/config/seo-service-details-slug.json
+++ b/app/config/seo-service-details-slug.json
@@ -6,5 +6,6 @@
   "business-permit-renewal": "Renew your annual Business License and Mayor's Permit in {{lguName}}.",
   "special-permit": "Apply for a Special Permit to operate your business establishment in {{lguName}}.",
   "occupational-permit": "Secure an Occupational Mayor's Permit for workers or employees in {{lguName}}.",
-  "occupational-permit-jobseeker": "Avail the free Occupational Mayor's Permit for First Time Job Seekers in {{lguName}} under RA 11261."
+  "occupational-permit-jobseeker": "Avail the free Occupational Mayor's Permit for First Time Job Seekers in {{lguName}} under RA 11261.",
+  "business-status-certificate": "Verify the status of a business entity registered with the BPLO in {{lguName}}."
 }

--- a/app/config/seo-service-details-slug.json
+++ b/app/config/seo-service-details-slug.json
@@ -5,5 +5,6 @@
   "business-permit-new": "Apply for a new Business License and Mayor's Permit in {{lguName}}.",
   "business-permit-renewal": "Renew your annual Business License and Mayor's Permit in {{lguName}}.",
   "special-permit": "Apply for a Special Permit to operate your business establishment in {{lguName}}.",
-  "occupational-permit": "Secure an Occupational Mayor's Permit for workers or employees in {{lguName}}."
+  "occupational-permit": "Secure an Occupational Mayor's Permit for workers or employees in {{lguName}}.",
+  "occupational-permit-jobseeker": "Avail the free Occupational Mayor's Permit for First Time Job Seekers in {{lguName}} under RA 11261."
 }

--- a/app/config/seo-service-details-slug.json
+++ b/app/config/seo-service-details-slug.json
@@ -4,5 +4,6 @@
   "death-certificate": "Register death certificate and obtain burial or transfer permit in {{lguName}}.",
   "business-permit-new": "Apply for a new Business License and Mayor's Permit in {{lguName}}.",
   "business-permit-renewal": "Renew your annual Business License and Mayor's Permit in {{lguName}}.",
-  "special-permit": "Apply for a Special Permit to operate your business establishment in {{lguName}}."
+  "special-permit": "Apply for a Special Permit to operate your business establishment in {{lguName}}.",
+  "occupational-permit": "Secure an Occupational Mayor's Permit for workers or employees in {{lguName}}."
 }

--- a/app/config/services.json
+++ b/app/config/services.json
@@ -174,6 +174,26 @@
       "url": "/service-details/special-permit"
     },
     {
+      "id": "occupational-permit",
+      "title": "Occupational Mayor's Permit (Regular)",
+      "category": "Business, Trade & Investment",
+      "categoryId": "business",
+      "description": "Apply for an Occupational Mayor's Permit for workers or employees",
+      "keywords": [
+        "occupational",
+        "permit",
+        "mayor",
+        "worker",
+        "employee",
+        "job",
+        "work"
+      ],
+      "fee": "Varies by Assessment",
+      "processingTime": "Approx. 3 hours",
+      "office": "Business Permits & Licensing Office",
+      "url": "/service-details/occupational-permit"
+    },
+    {
       "id": "business-closure",
       "title": "Business Closure",
       "category": "Business, Trade & Investment",

--- a/app/config/services.json
+++ b/app/config/services.json
@@ -174,6 +174,26 @@
       "url": "/service-details/special-permit"
     },
     {
+      "id": "business-status-certificate",
+      "title": "Certificates on Status of Business",
+      "category": "Business, Trade & Investment",
+      "categoryId": "business",
+      "description": "Certification on the status of business entity registered in Las Piñas",
+      "keywords": [
+        "certificate",
+        "certification",
+        "status",
+        "business",
+        "verify",
+        "BPLO",
+        "business license"
+      ],
+      "fee": "₱75 + ₱15/page",
+      "processingTime": "Approx. 1 hour",
+      "office": "Business Permits & Licensing Office",
+      "url": "/service-details/business-status-certificate"
+    },
+    {
       "id": "occupational-permit",
       "title": "Occupational Mayor's Permit (Regular)",
       "category": "Business, Trade & Investment",

--- a/app/config/services.json
+++ b/app/config/services.json
@@ -194,6 +194,30 @@
       "url": "/service-details/occupational-permit"
     },
     {
+      "id": "occupational-permit-jobseeker",
+      "title": "Occupational Mayor's Permit (First Time Job Seeker)",
+      "category": "Business, Trade & Investment",
+      "categoryId": "business",
+      "description": "Free Occupational Mayor's Permit for first-time job seekers (R.A. 11261)",
+      "keywords": [
+        "occupational",
+        "permit",
+        "mayor",
+        "worker",
+        "employee",
+        "job",
+        "work",
+        "first time",
+        "job seeker",
+        "jobseeker",
+        "free"
+      ],
+      "fee": "Free",
+      "processingTime": "Approx. 3 hours",
+      "office": "Business Permits & Licensing Office",
+      "url": "/service-details/occupational-permit-jobseeker"
+    },
+    {
       "id": "business-closure",
       "title": "Business Closure",
       "category": "Business, Trade & Investment",

--- a/app/utils/categoriesContent.ts
+++ b/app/utils/categoriesContent.ts
@@ -146,6 +146,15 @@ export const categoriesContent: CategoryContent[] = [
         link: '/service-details/special-permit',
       },
       {
+        id: 'occupational-permit',
+        title: 'Occupational Mayor\'s Permit',
+        icon: 'bi-person-vcard',
+        description: 'Occupational Mayor\'s Permit for workers or employees',
+        fee: 'Varies by Assessment',
+        time: 'Approx. 3 hours',
+        link: '/service-details/occupational-permit',
+      },
+      {
         id: 'mayors-clearance',
         title: 'Mayor\'s Clearance',
         icon: 'bi-patch-check',

--- a/app/utils/categoriesContent.ts
+++ b/app/utils/categoriesContent.ts
@@ -155,6 +155,15 @@ export const categoriesContent: CategoryContent[] = [
         link: '/service-details/occupational-permit',
       },
       {
+        id: 'occupational-permit-jobseeker',
+        title: 'Occupational Permit (First Time Job Seeker)',
+        icon: 'bi-person-check',
+        description: 'Free Occupational Mayor\'s Permit for first-time job seekers (R.A. 11261)',
+        fee: 'Free',
+        time: 'Approx. 3 hours',
+        link: '/service-details/occupational-permit-jobseeker',
+      },
+      {
         id: 'mayors-clearance',
         title: 'Mayor\'s Clearance',
         icon: 'bi-patch-check',

--- a/app/utils/categoriesContent.ts
+++ b/app/utils/categoriesContent.ts
@@ -146,6 +146,15 @@ export const categoriesContent: CategoryContent[] = [
         link: '/service-details/special-permit',
       },
       {
+        id: 'business-status-certificate',
+        title: 'Certificates on Status of Business',
+        icon: 'bi-file-earmark-check',
+        description: 'Certification on the status of a business entity registered in Las Piñas',
+        fee: '₱75 + ₱15/page',
+        time: 'Approx. 1 hour',
+        link: '/service-details/business-status-certificate',
+      },
+      {
         id: 'occupational-permit',
         title: 'Occupational Mayor\'s Permit',
         icon: 'bi-person-vcard',

--- a/app/utils/serviceDetailsContent.ts
+++ b/app/utils/serviceDetailsContent.ts
@@ -842,6 +842,94 @@ export const serviceDetailsContent: ServiceDetail[] = [
     sourceName: 'Citizen\'s Charter 2022 (1st Edition)',
   },
   {
+    id: 'business-status-certificate',
+    title: 'Business Status Certificate',
+    fullTitle: 'Issuance of Certificates on Status of Business',
+    category: 'Business',
+    categoryLink: '/services/business',
+    badgeText: 'Business',
+    badgeIcon: 'bi-file-earmark-check',
+    description: 'Certification issued by the City Government to all who want to verify the status of a business entity registered with the BPLO. Information access is limited pursuant to the Data Privacy Act of 2012 to maintain record integrity.',
+    quickStats: [
+      { icon: 'bi-clock', label: 'Processing', value: 'Approx. 1 hour' },
+      { icon: 'bi-cash', label: 'Fee', value: '₱75 + ₱15/page' },
+      {
+        icon: 'bi-person-check',
+        label: 'Who Can Apply',
+        value: 'Government & Private Sector',
+      },
+      { icon: 'bi-calendar-check', label: 'Appointment', value: 'Walk-in' },
+    ],
+    processSteps: [
+      {
+        title: 'Submit Application & Requirements',
+        description: 'Fill up the application form and submit the request letter together with other required documents to BPLO frontliners for review and validation. BPLO will verify records and issue an Order of Payment.',
+      },
+      {
+        title: 'Pay the Fee',
+        description: 'Proceed to the Office of the City Treasurer\'s – Miscellaneous Division and pay ₱75, plus ₱15 per additional page. An Official Receipt will be issued.',
+      },
+      {
+        title: 'Claim the Certification',
+        description: 'Return to BPLO for the processing and printing of the Certification, signing by the Chief BPLO, and release to the applicant.',
+        isFinal: true,
+      },
+    ],
+    requirements: [
+      {
+        title: 'Documentary Requirements',
+        icon: 'bi-file-text',
+        items: [
+          'Request Letter indicating the name of requestor and purpose of certification',
+          'Identification Card',
+          'Barangay Clearance',
+          'Assessor\'s Certificate',
+          'Referral letter from Hospital/DSWD/PAO or other government agencies (if applicable)',
+        ],
+      },
+      {
+        title: 'If Applying Through a Representative',
+        icon: 'bi-people',
+        items: [
+          'Letter of Authority, Special Power of Attorney, or Secretary Certificate',
+          'Valid ID of both the owner and representative',
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: 'What is the purpose of this certification?',
+        answer: 'This certification is used to verify the legal status of a business entity registered in Las Piñas City. It is accepted for legal, government, and private transactions.',
+      },
+      {
+        question: 'Why is access to business records limited?',
+        answer: 'Pursuant to the Data Privacy Act of 2012 (RA 10173), the BPLO limits the data that can be accessed to protect the integrity and privacy of the information in its records.',
+      },
+    ],
+    office: {
+      name: 'Business Permits & Licensing Office',
+      location: 'City Hall, Ground Floor',
+      phone: '(02) 8551-5930',
+      hours: 'Mon-Thu: 8AM - 7PM',
+    },
+    relatedServices: [
+      {
+        title: 'Business Permit (New)',
+        link: '/service-details/business-permit-new',
+      },
+      {
+        title: 'Business Permit Renewal',
+        link: '/service-details/business-permit-renewal',
+      },
+      {
+        title: 'Special Permit',
+        link: '/service-details/special-permit',
+      },
+    ],
+    sourceUrl: 'https://laspinascity.gov.ph/storage/uploads/gallery/625e67f3ae023.pdf',
+    sourceName: 'Citizen\'s Charter 2022 (1st Edition)',
+  },
+  {
     id: 'occupational-permit',
     title: 'Occupational Mayor\'s Permit',
     fullTitle: 'Occupational Mayor\'s Permit (Regular)',
@@ -914,6 +1002,10 @@ export const serviceDetailsContent: ServiceDetail[] = [
       hours: 'Mon-Thu: 8AM - 7PM',
     },
     relatedServices: [
+      {
+        title: 'Occupational Mayor\'s Permit (First Time Job Seeker)',
+        link: '/service-details/occupational-permit-jobseeker',
+      },
       {
         title: 'Business Permit (New)',
         link: '/service-details/business-permit-new',

--- a/app/utils/serviceDetailsContent.ts
+++ b/app/utils/serviceDetailsContent.ts
@@ -849,7 +849,7 @@ export const serviceDetailsContent: ServiceDetail[] = [
     categoryLink: '/services/business',
     badgeText: 'Business',
     badgeIcon: 'bi-file-earmark-check',
-    description: 'Certification issued by the City Government to all who want to verify the status of a business entity registered with the BPLO. Information access is limited pursuant to the Data Privacy Act of 2012 to maintain record integrity.',
+    description: 'Certification issued by the City Government to all who want to verify the status of a business entity registered with the Business Permit and Licensing Office (BPLO). Information access is limited pursuant to the Data Privacy Act of 2012 to maintain record integrity.',
     quickStats: [
       { icon: 'bi-clock', label: 'Processing', value: 'Approx. 1 hour' },
       { icon: 'bi-cash', label: 'Fee', value: '₱75 + ₱15/page' },
@@ -863,7 +863,7 @@ export const serviceDetailsContent: ServiceDetail[] = [
     processSteps: [
       {
         title: 'Submit Application & Requirements',
-        description: 'Fill up the application form and submit the request letter together with other required documents to BPLO frontliners for review and validation. BPLO will verify records and issue an Order of Payment.',
+        description: 'Fill out the application form and submit the request letter together with other required documents to the BPLO frontliners for review and validation. The BPLO will verify records and issue an Order of Payment.',
       },
       {
         title: 'Pay the Fee',
@@ -871,7 +871,7 @@ export const serviceDetailsContent: ServiceDetail[] = [
       },
       {
         title: 'Claim the Certification',
-        description: 'Return to BPLO for the processing and printing of the Certification, signing by the Chief BPLO, and release to the applicant.',
+        description: 'Return to the BPLO for the processing and printing of the Certification, signing by the Chief of BPLO, and release to the applicant.',
         isFinal: true,
       },
     ],
@@ -959,7 +959,7 @@ export const serviceDetailsContent: ServiceDetail[] = [
       },
       {
         title: 'Assessment and Payment',
-        description: 'Proceed through the assessment and pay the assessed fees as directed by BPLO personnel.',
+        description: 'Proceed through the assessment and pay the assessed fees as directed by the BPLO personnel.',
       },
       {
         title: 'Claim Permit',

--- a/app/utils/serviceDetailsContent.ts
+++ b/app/utils/serviceDetailsContent.ts
@@ -927,6 +927,97 @@ export const serviceDetailsContent: ServiceDetail[] = [
     sourceName: 'Citizen\'s Charter 2022 (1st Edition)',
   },
   {
+    id: 'occupational-permit-jobseeker',
+    title: 'Occupational Mayor\'s Permit (First Time Job Seeker)',
+    fullTitle: 'Occupational Mayor\'s Permit (First Time Job Seeker)',
+    category: 'Business',
+    categoryLink: '/services/business',
+    badgeText: 'Business',
+    badgeIcon: 'bi-person-check',
+    description: 'The City Government of Las Piñas provides assistance to "First Time Job Seekers" regarding the issuance of an Occupational Mayor’s Permit, in compliance with Republic Act No. 11261, the "First Time Jobseekers Assistance Act" of 2019.',
+    quickStats: [
+      { icon: 'bi-clock', label: 'Processing', value: 'Approx. 3 hours' },
+      { icon: 'bi-cash', label: 'Fee', value: 'Free' },
+      {
+        icon: 'bi-person-check',
+        label: 'Who Can Apply',
+        value: 'First-time Job Seekers',
+      },
+      { icon: 'bi-calendar-check', label: 'Appointment', value: 'Walk-in' },
+    ],
+    processSteps: [
+      {
+        title: 'Secure Application Form',
+        description: 'Secure and fill out the application form at the Business Permit and Licensing Office (BPLO).',
+      },
+      {
+        title: 'Submit Requirements',
+        description: 'Submit the application form along with the required documents such as Cedula, NBI/Police Clearance, and your Barangay Certificate with First-time job seeker undertaking.',
+      },
+      {
+        title: 'Assessment and Evaluation',
+        description: 'Proceed through the assessment where personnel will evaluate your requirements and check your Barangay Certificate to waive local fees.',
+      },
+      {
+        title: 'Claim Permit',
+        description: 'Claim the Occupational Mayor\'s Permit once processed and approved.',
+        isFinal: true,
+      },
+    ],
+    requirements: [
+      {
+        title: 'Documentary Requirements',
+        icon: 'bi-file-text',
+        items: [
+          'Barangay Certificate with an undertaking stating you are a first-time job seeker (RA 11261)',
+          'Application Form (2 copies - secured from BPLO)',
+          'Community Tax Certificate (Cedula)',
+          'NBI Clearance or Police Clearance',
+        ],
+      },
+      {
+        title: 'Additional Medical Requirements',
+        icon: 'bi-heart-pulse',
+        items: [
+          'Medical Results (X-Ray Result)',
+          'Urine and Stool test results (specifically required for food handlers)',
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: 'Who is considered a First Time Job Seeker?',
+        answer: 'A First Time Job Seeker is defined as a Filipino citizen looking for work for the first time, who is between 15 to 30 years old, and not currently receiving benefits from other government job programs.',
+      },
+      {
+        question: 'Are all fees waived under RA 11261?',
+        answer: 'Yes, government regulatory fees for standard documents such as the Occupational Permit, Barangay Clearance, and NBI Clearance are free of charge for valid first-time job seekers.',
+      },
+      {
+        question: 'What if I am a food handler?',
+        answer: 'If you are applying as a food handler, you will be required to submit specific test results (Urine and Stool) and also undergo a seminar at the Sanitation Office.',
+      },
+    ],
+    office: {
+      name: 'Business Permits & Licensing Office',
+      location: 'City Hall, Ground Floor',
+      phone: '(02) 8551-5930',
+      hours: 'Mon-Thu: 8AM - 7PM',
+    },
+    relatedServices: [
+      {
+        title: 'Occupational Mayor\'s Permit (Regular)',
+        link: '/service-details/occupational-permit',
+      },
+      {
+        title: 'Sanitary Permit',
+        link: '/services/business',
+      },
+    ],
+    sourceUrl: 'https://laspinascity.gov.ph/storage/uploads/gallery/625e67f3ae023.pdf',
+    sourceName: 'Citizen\'s Charter 2022 (1st Edition)',
+  },
+  {
     id: 'tricycle-franchising',
     hidden: true,
     title: 'Tricycle Franchising',

--- a/app/utils/serviceDetailsContent.ts
+++ b/app/utils/serviceDetailsContent.ts
@@ -842,6 +842,91 @@ export const serviceDetailsContent: ServiceDetail[] = [
     sourceName: 'Citizen\'s Charter 2022 (1st Edition)',
   },
   {
+    id: 'occupational-permit',
+    title: 'Occupational Mayor\'s Permit',
+    fullTitle: 'Occupational Mayor\'s Permit (Regular)',
+    category: 'Business',
+    categoryLink: '/services/business',
+    badgeText: 'Business',
+    badgeIcon: 'bi-person-vcard',
+    description: 'The Occupational Mayor\'s Permit is issued by the City Government to all workers or employees (temporary or permanent) employed within the territorial jurisdiction of Las Piñas, pursuant to the local Revenue Code.',
+    quickStats: [
+      { icon: 'bi-clock', label: 'Processing', value: 'Approx. 3 hours' },
+      { icon: 'bi-cash', label: 'Fee', value: 'Varies by Assessment' },
+      {
+        icon: 'bi-person-check',
+        label: 'Who Can Apply',
+        value: 'Workers & Employees',
+      },
+      { icon: 'bi-calendar-check', label: 'Appointment', value: 'Walk-in' },
+    ],
+    processSteps: [
+      {
+        title: 'Secure Application Form',
+        description: 'Secure and fill out the application form at the Business Permit and Licensing Office (BPLO).',
+      },
+      {
+        title: 'Submit Requirements',
+        description: 'Submit the application form along with the required documents such as Cedula and NBI/Police Clearance for evaluation.',
+      },
+      {
+        title: 'Assessment and Payment',
+        description: 'Proceed through the assessment and pay the assessed fees as directed by BPLO personnel.',
+      },
+      {
+        title: 'Claim Permit',
+        description: 'Claim the Occupational Mayor\'s Permit once processed and approved.',
+        isFinal: true,
+      },
+    ],
+    requirements: [
+      {
+        title: 'Documentary Requirements',
+        icon: 'bi-file-text',
+        items: [
+          'Application Form (2 copies - secured from BPLO)',
+          'Community Tax Certificate (Cedula)',
+          'NBI Clearance or Police Clearance',
+        ],
+      },
+      {
+        title: 'For First-Time Jobseekers (R.A. 11261)',
+        icon: 'bi-person-plus',
+        items: [
+          'Barangay Certificate with an undertaking stating you are a first-time job seeker to avail the assistance.',
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: 'What is the processing time for the permit?',
+        answer: 'The BPLO classifies the issuance of the Occupational Mayor\'s Permit as a simple transaction, typically taking around 3 hours depending on the volume of applicants.',
+      },
+      {
+        question: 'Do I need to apply in person?',
+        answer: 'While in-person application is standard, the city has been integrating services online. Please check the official Las Piñas City website for recent updates.',
+      },
+    ],
+    office: {
+      name: 'Business Permits & Licensing Office',
+      location: 'City Hall, Ground Floor',
+      phone: '(02) 8551-5930',
+      hours: 'Mon-Thu: 8AM - 7PM',
+    },
+    relatedServices: [
+      {
+        title: 'Business Permit (New)',
+        link: '/service-details/business-permit-new',
+      },
+      {
+        title: 'Special Permit',
+        link: '/service-details/special-permit',
+      },
+    ],
+    sourceUrl: 'https://laspinascity.gov.ph/storage/uploads/gallery/625e67f3ae023.pdf',
+    sourceName: 'Citizen\'s Charter 2022 (1st Edition)',
+  },
+  {
     id: 'tricycle-franchising',
     hidden: true,
     title: 'Tricycle Franchising',


### PR DESCRIPTION
## Description

This PR adds three new services under the **Business, Trade & Investment** category, expanding the Citizen's Charter coverage in the BetterLasPiñas application.

The three services added are:

1. **Occupational Mayor's Permit (Regular)** — Full Citizen's Charter details for the standard occupational permit issued through the BPLO.
2. **Occupational Mayor's Permit (First Time Job Seeker)** — Highlights free assistance available under R.A. 11261 for first-time job seekers.
3. **Certificates on Status of Business** — Allows users to verify a registered business entity's status via the BPLO.

Fixes #117 #118

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Manually verified each new service page is accessible and renders correctly with the expected content (processing steps, documentary requirements, office information, and fees).

- [x] Navigated to each new service detail page and confirmed correct rendering
- [x] Verified services appear in the Business, Trade & Investment category listing
- [x] Confirmed no TypeScript errors or build warnings introduced

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have added my changes to the `Unreleased` section of `CHANGELOG.md`

