### PR TITLE
chore: align Dependabot to fleet standard (monthly + minor-and-patch grouping)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: npm        # reads pnpm-lock.yaml
+  - package-ecosystem: npm # reads pnpm-lock.yaml
     directory: /
     schedule:
       interval: monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,89 +1,16 @@
 version: 2
-
 updates:
-  # ── pnpm packages ──────────────────────────────────────────────
-  - package-ecosystem: npm
+  - package-ecosystem: npm        # reads pnpm-lock.yaml
     directory: /
     schedule:
-      interval: weekly
-      day: monday
-      time: '09:00'
-      timezone: Asia/Manila
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-      - pnpm
-    commit-message:
-      prefix: chore
-      prefix-development: chore
-      include: scope
+      interval: monthly
     groups:
-      nuxt-ecosystem:
-        patterns:
-          - nuxt
-          - '@nuxt/*'
-          - nuxi
-          - vue
-          - 'vue-*'
-          - '@vue/*'
-          - vue-router
-      tailwind:
-        patterns:
-          - tailwindcss
-          - '@tailwindcss/*'
-          - 'tailwind-*'
-          - autoprefixer
-          - postcss
-      pinia:
-        patterns:
-          - pinia
-          - '@pinia/*'
-      ui-and-icons:
-        patterns:
-          - lucide-vue-next
-          - bootstrap-icons
-          - '@headlessui/*'
-          - clsx
-          - tailwind-merge
-      charts-and-maps:
-        patterns:
-          - chart.js
-          - vue-chartjs
-          - leaflet
-          - '@vue-leaflet/*'
-          - '@types/leaflet'
-      testing:
-        patterns:
-          - vitest
-          - '@vitest/*'
-          - '@nuxt/test-utils'
-          - '@vue/test-utils'
-          - happy-dom
-      linting-and-tooling:
-        patterns:
-          - eslint
-          - 'eslint-*'
-          - '@antfu/eslint-config'
-          - husky
-          - typescript
-          - vue-tsc
-
-  # ── GitHub Actions ─────────────────────────────────────────────
+      minor-and-patch:
+        update-types: [minor, patch]
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: monday
-      time: '09:00'
-      timezone: Asia/Manila
-    open-pull-requests-limit: 5
-    labels:
-      - dependencies
-      - github-actions
-    commit-message:
-      prefix: chore
-      include: scope
+      interval: monthly
     groups:
-      github-actions:
-        patterns:
-          - '*'
+      minor-and-patch:
+        update-types: [minor, patch]


### PR DESCRIPTION
Closes #191.

Rewrites `.github/dependabot.yml` to the fleet standard:

- **Cadence:** `interval: monthly` for both ecosystems (security advisories still fire immediately regardless of interval).
- **Grouping:** one `minor-and-patch` group per ecosystem → a single PR per ecosystem per month.
- **Majors:** excluded from the group → each major lands as its own reviewable PR.

Drops the old `weekly` cadence, `labels`, `commit-message`, `open-pull-requests-limit`, and the granular per-tool groups (nuxt-ecosystem, tailwind, pinia, etc.).

### Acceptance criteria
- [x] `.github/dependabot.yml` matches the target config
- [x] All ecosystems use `interval: monthly`
- [x] Each ecosystem has a single `minor-and-patch` group (`update-types: [minor, patch]`)
- [ ] Major bumps arrive as individual PRs (verified after first run)
- [ ] Dependabot validates the file with no parse errors (Insights → Dependency graph → Dependabot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)