### PR TITLE
feat(services): Office as first-class entity + Office Group browsing (closes #185)

### DIFF
--- a/app/config/categories.json
+++ b/app/config/categories.json
@@ -6,22 +6,7 @@
       "name": "Certificates & Vital Records",
       "icon": "bi-file-earmark-text-fill",
       "badgeText": "Certificates",
-      "description": "Official documents for birth, death, marriage, and other vital records",
-      "offices": [
-        {
-          "title": "City Civil Registry",
-          "icon": "bi-building",
-          "description": "Birth, death, marriage registration, corrections, and certified copies",
-          "link": "/service-details/city-civil-registry"
-        },
-        {
-          "title": "Human Resource Management",
-          "icon": "bi-people",
-          "description": "Service records, employment certificates, leave credits for LGU employees",
-          "link": "/service-details/human-resource-management",
-          "hidden": true
-        }
-      ]
+      "description": "Official documents for birth, death, marriage, and other vital records"
     },
     {
       "id": "business",

--- a/app/config/offices.json
+++ b/app/config/offices.json
@@ -35,7 +35,8 @@
       "groupId": "frontline-services",
       "icon": "bi-house",
       "description": "Barangay clearances, IDs, and certificates of residency",
-      "link": "/services/certificates"
+      "link": "/services/certificates",
+      "hidden": true
     },
     {
       "id": "police-station",
@@ -43,7 +44,8 @@
       "groupId": "frontline-services",
       "icon": "bi-shield",
       "description": "Police clearances and community safety coordination",
-      "link": "/services/certificates"
+      "link": "/services/certificates",
+      "hidden": true
     },
     {
       "id": "human-resource-management",

--- a/app/config/offices.json
+++ b/app/config/offices.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "./schema/offices.schema.json",
+  "officeGroups": [
+    {
+      "id": "frontline-services",
+      "name": "Frontline Services",
+      "description": "Resident-facing offices that issue documents and handle day-to-day transactions",
+      "icon": "bi-people"
+    },
+    {
+      "id": "administration",
+      "name": "Administration",
+      "description": "Internal governance, personnel, and records offices of the LGU",
+      "icon": "bi-building-gear"
+    }
+  ],
+  "offices": [
+    {
+      "id": "civil-registry",
+      "name": "City Civil Registry",
+      "groupId": "frontline-services",
+      "icon": "bi-building",
+      "description": "Birth, death, marriage registration, corrections, and certified copies",
+      "link": "/service-details/birth-certificate",
+      "location": "1st Floor, Administrative Building, Las Piñas City Hall Compound",
+      "phone": "(02) 8253-4370",
+      "mobile": "0998 587 9659",
+      "email": "lpcivilreg@gmail.com",
+      "facebook": "https://www.facebook.com/civilreglaspinas",
+      "hours": "Mon-Thu: 8AM - 7PM"
+    },
+    {
+      "id": "barangay-hall",
+      "name": "Barangay Hall",
+      "groupId": "frontline-services",
+      "icon": "bi-house",
+      "description": "Barangay clearances, IDs, and certificates of residency",
+      "link": "/services/certificates"
+    },
+    {
+      "id": "police-station",
+      "name": "PNP Station",
+      "groupId": "frontline-services",
+      "icon": "bi-shield",
+      "description": "Police clearances and community safety coordination",
+      "link": "/services/certificates"
+    },
+    {
+      "id": "human-resource-management",
+      "name": "Human Resource Management",
+      "groupId": "administration",
+      "icon": "bi-people",
+      "description": "Service records, employment certificates, leave credits for LGU employees",
+      "link": "/service-details/human-resource-management",
+      "hidden": true
+    }
+  ]
+}

--- a/app/config/schema/categories.schema.json
+++ b/app/config/schema/categories.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "categories.schema.json",
   "title": "Categories Configuration",
-  "description": "Service categories. Each category may carry a list of responsible offices (lightweight catalog cards, not the full Office entity).",
+  "description": "Service categories: groupings used to organize Services for browsing by task. Categories apply to Services only, never Offices (Offices are a first-class entity in offices.json, grouped by Office Group).",
   "type": "object",
   "required": ["categories"],
   "properties": {
@@ -33,23 +33,6 @@
         },
         "badgeText": { "type": "string" },
         "description": { "type": "string" },
-        "hidden": { "type": "boolean" },
-        "offices": {
-          "type": "array",
-          "description": "Responsible offices shown on the category page",
-          "items": { "$ref": "#/definitions/categoryOffice" }
-        }
-      }
-    },
-    "categoryOffice": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["title", "icon", "description", "link"],
-      "properties": {
-        "title": { "type": "string" },
-        "icon": { "type": "string" },
-        "description": { "type": "string" },
-        "link": { "type": "string" },
         "hidden": { "type": "boolean" }
       }
     }

--- a/app/config/schema/offices.schema.json
+++ b/app/config/schema/offices.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "offices.schema.json",
+  "title": "Offices Configuration",
+  "description": "First-class Office entity. An Office is a government body that provides Services, grouped by government function via an Office Group. An Office belongs to exactly one Office Group, even when its Services span multiple Categories.",
+  "type": "object",
+  "required": ["officeGroups", "offices"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference"
+    },
+    "officeGroups": {
+      "type": "array",
+      "description": "Office Groups: groupings of Offices by government function (who runs this)",
+      "items": { "$ref": "#/definitions/officeGroup" }
+    },
+    "offices": {
+      "type": "array",
+      "description": "All Office records, each belonging to exactly one Office Group",
+      "items": { "$ref": "#/definitions/office" }
+    }
+  },
+  "definitions": {
+    "officeGroup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "description"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique Office Group slug (matches offices[].groupId)"
+        },
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "icon": {
+          "type": "string",
+          "description": "Bootstrap icon class"
+        },
+        "hidden": { "type": "boolean" }
+      }
+    },
+    "office": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "groupId", "icon", "description", "link"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique, URL-friendly Office identifier (referenced by services[].providedBy)"
+        },
+        "name": { "type": "string" },
+        "groupId": {
+          "type": "string",
+          "description": "Slug of the parent Office Group (must match an officeGroups id). Exactly one."
+        },
+        "icon": {
+          "type": "string",
+          "description": "Bootstrap icon class"
+        },
+        "description": { "type": "string" },
+        "link": {
+          "type": "string",
+          "description": "Destination route for the Office card"
+        },
+        "location": { "type": "string" },
+        "phone": { "type": "string" },
+        "mobile": { "type": "string" },
+        "email": { "type": "string" },
+        "facebook": { "type": "string" },
+        "hours": { "type": "string" },
+        "hidden": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/app/config/schema/services.schema.json
+++ b/app/config/schema/services.schema.json
@@ -105,7 +105,7 @@
           "type": "array",
           "items": { "$ref": "#/definitions/faq" }
         },
-        "office": { "$ref": "#/definitions/office" },
+        "office": { "$ref": "#/definitions/serviceDetailOffice" },
         "relatedServices": {
           "type": "array",
           "items": { "$ref": "#/definitions/relatedService" }
@@ -157,7 +157,7 @@
         "answer": { "type": "string" }
       }
     },
-    "office": {
+    "serviceDetailOffice": {
       "type": "object",
       "additionalProperties": false,
       "required": ["name", "location", "hours"],

--- a/app/config/schema/services.schema.json
+++ b/app/config/schema/services.schema.json
@@ -42,6 +42,10 @@
           "description": "Search terms for the fuzzy search composable"
         },
         "office": { "type": "string" },
+        "providedBy": {
+          "type": "string",
+          "description": "Slug of the Office that provides this Service (must match an offices.json id). The first-class Service -> providedBy -> Office reference."
+        },
         "fee": { "type": "string" },
         "processingTime": { "type": "string" },
         "url": {

--- a/app/config/services.json
+++ b/app/config/services.json
@@ -19,6 +19,7 @@
       "fee": "₱75",
       "processingTime": "15-30 minutes",
       "office": "Civil Registry Office",
+      "providedBy": "civil-registry",
       "icon": "bi-file-earmark-text",
       "url": "/service-details/birth-certificate",
       "detail": {
@@ -103,6 +104,7 @@
       "fee": "₱150 (Registration)",
       "processingTime": "3-10 days",
       "office": "Civil Registry Office",
+      "providedBy": "civil-registry",
       "icon": "bi-heart",
       "url": "/service-details/marriage-certificate",
       "detail": {
@@ -194,6 +196,7 @@
       "fee": "₱75-150",
       "processingTime": "~1 hour 35 minutes",
       "office": "Civil Registry Office",
+      "providedBy": "civil-registry",
       "icon": "bi-file-earmark-x",
       "url": "/service-details/death-certificate",
       "detail": {
@@ -274,6 +277,7 @@
       "fee": "₱50-100",
       "processingTime": "Same day",
       "office": "Barangay Hall",
+      "providedBy": "barangay-hall",
       "icon": "bi-house-check",
       "url": "/services/certificates"
     },
@@ -292,6 +296,7 @@
       "fee": "Free",
       "processingTime": "1-2 days",
       "office": "Barangay Hall",
+      "providedBy": "barangay-hall",
       "icon": "bi-person-badge",
       "url": "/services/certificates"
     },
@@ -311,6 +316,7 @@
       "fee": "Varies",
       "processingTime": "3-5 days",
       "office": "PNP Station",
+      "providedBy": "police-station",
       "icon": "bi-shield-check",
       "url": "/services/certificates"
     },

--- a/app/pages/services/[category].vue
+++ b/app/pages/services/[category].vue
@@ -45,9 +45,25 @@ const services = canonical
       time: service.time,
       link: service.link,
     }))
-const offices = (canonical?.offices ?? legacy?.offices ?? []).filter(
-  office => !office.hidden,
-)
+// Responsible Offices. For a canonical Category, Offices are first-class
+// entities (#185) resolved from the Category's Services via providedBy —
+// Office <-> Category is many-to-many through the Services. Legacy categories
+// still carry inline office cards from categoriesContent.ts until ported.
+const offices = canonical
+  ? getOfficesForCategory(categorySlug).map(office => ({
+      title: office.name,
+      icon: office.icon,
+      description: office.description,
+      link: office.link,
+    }))
+  : (legacy?.offices ?? [])
+      .filter(office => !office.hidden)
+      .map(office => ({
+        title: office.title,
+        icon: office.icon,
+        description: office.description,
+        link: office.link,
+      }))
 </script>
 
 <template>

--- a/app/types/config.ts
+++ b/app/types/config.ts
@@ -361,7 +361,12 @@ export interface Faq {
   answer: string
 }
 
-export interface Office {
+/**
+ * Office-contact block embedded in a Service's `detail` (the "Office
+ * Information" card on a /service-details page). This is NOT the first-class
+ * Office entity — see `Office` / `OfficeGroup` below and offices.json.
+ */
+export interface ServiceDetailOffice {
   name: string
   location: string
   phone?: string
@@ -387,7 +392,7 @@ export interface ServiceDetail {
   processSteps: ProcessStep[]
   requirements: RequirementGroup[]
   faqs: Faq[]
-  office: Office
+  office: ServiceDetailOffice
   relatedServices: RelatedService[]
   onlineLink?: string
   sourceUrl?: string
@@ -402,6 +407,11 @@ export interface ServiceItem {
   categoryId?: string
   keywords: string[]
   office?: string
+  /**
+   * Slug of the first-class Office that provides this Service (matches an
+   * offices.json id). Resolve through `getOfficeBySlug`. See `Office` below.
+   */
+  providedBy?: string
   fee?: string
   processingTime?: string
   url: string
@@ -437,18 +447,6 @@ export interface NavigationConfig {
   }
 }
 
-/**
- * A responsible office shown on a category page ("Responsible Offices").
- * This is a lightweight catalog card, NOT the full Office entity (see #185).
- */
-export interface CategoryOffice {
-  title: string
-  icon: string
-  description: string
-  link: string
-  hidden?: boolean
-}
-
 export interface Category {
   id: string
   name: string
@@ -456,11 +454,50 @@ export interface Category {
   badgeText: string
   description: string
   hidden?: boolean
-  offices?: CategoryOffice[]
 }
 
 export interface CategoriesConfig {
   categories: Category[]
+  [key: string]: unknown
+}
+
+/**
+ * Office Group: a grouping of Offices by government function (answers "who runs
+ * this", e.g. "Frontline Services", "Finance"). Distinct from Category, which
+ * groups Services by task. Groups Offices one-to-many.
+ */
+export interface OfficeGroup {
+  id: string
+  name: string
+  description: string
+  icon?: string
+  hidden?: boolean
+}
+
+/**
+ * First-class Office entity: a government body that provides Services. Belongs
+ * to exactly one Office Group via `groupId`, even when its Services span
+ * multiple Categories. Referenced by ServiceItem.providedBy.
+ */
+export interface Office {
+  id: string
+  name: string
+  groupId: string
+  icon: string
+  description: string
+  link: string
+  location?: string
+  phone?: string
+  mobile?: string
+  email?: string
+  facebook?: string
+  hours?: string
+  hidden?: boolean
+}
+
+export interface OfficesConfig {
+  officeGroups: OfficeGroup[]
+  offices: Office[]
   [key: string]: unknown
 }
 

--- a/app/utils/configHelper.test.ts
+++ b/app/utils/configHelper.test.ts
@@ -4,6 +4,13 @@ import {
   getAllServices,
   getCategoryBySlug,
   getMergedSiteConfig,
+  getOfficeBySlug,
+  getOfficeForService,
+  getOfficeGroupBySlug,
+  getOfficeGroups,
+  getOffices,
+  getOfficesByGroup,
+  getOfficesForCategory,
   getOgImageConfig,
   getOgImageRouteConfig,
   getServiceBySlug,
@@ -109,12 +116,13 @@ describe('configHelper', () => {
       expect(categories.every(c => !c.hidden)).toBe(true)
     })
 
-    it('getCategoryBySlug returns a category with offices', () => {
+    it('getCategoryBySlug returns the certificates category (no inline offices)', () => {
       const cert = getCategoryBySlug('certificates')
       expect(cert).toBeDefined()
       expect(cert!.name).toBe('Certificates & Vital Records')
-      const visibleOffices = (cert!.offices ?? []).filter(o => !o.hidden)
-      expect(visibleOffices.find(o => o.title === 'City Civil Registry')).toBeDefined()
+      // Offices are a first-class entity now (#185); Category no longer carries
+      // an inline `offices` array.
+      expect('offices' in cert!).toBe(false)
     })
 
     it('getCategoryBySlug returns undefined for unknown slug', () => {
@@ -146,6 +154,81 @@ describe('configHelper', () => {
 
     it('getServiceBySlug returns undefined for unknown slug', () => {
       expect(getServiceBySlug('not-a-real-service')).toBeUndefined()
+    })
+  })
+
+  describe('canonical Office accessor', () => {
+    it('getOffices returns visible Offices only', () => {
+      const offices = getOffices()
+      expect(offices.length).toBeGreaterThan(0)
+      expect(offices.every(o => !o.hidden)).toBe(true)
+      // The hidden Human Resource Management office is excluded.
+      expect(offices.find(o => o.id === 'human-resource-management')).toBeUndefined()
+    })
+
+    it('each Office belongs to exactly one (known) Office Group', () => {
+      const groupIds = new Set(getOfficeGroups().map(g => g.id))
+      // Every visible office resolves to a single, known group via groupId.
+      for (const office of getOffices()) {
+        expect(typeof office.groupId).toBe('string')
+        expect(groupIds.has(office.groupId)).toBe(true)
+      }
+    })
+
+    it('getOfficeBySlug resolves a known Office', () => {
+      const civil = getOfficeBySlug('civil-registry')
+      expect(civil).toBeDefined()
+      expect(civil!.name).toBe('City Civil Registry')
+      expect(civil!.groupId).toBe('frontline-services')
+    })
+
+    it('getOfficeBySlug returns undefined for unknown or hidden Offices', () => {
+      expect(getOfficeBySlug('not-a-real-office')).toBeUndefined()
+      expect(getOfficeBySlug('human-resource-management')).toBeUndefined()
+    })
+
+    it('getOfficeGroups returns visible Office Groups', () => {
+      const groups = getOfficeGroups()
+      expect(groups.length).toBeGreaterThan(0)
+      expect(groups.every(g => !g.hidden)).toBe(true)
+      expect(groups.find(g => g.id === 'frontline-services')).toBeDefined()
+    })
+
+    it('getOfficeGroupBySlug returns undefined for unknown slug', () => {
+      expect(getOfficeGroupBySlug('does-not-exist')).toBeUndefined()
+    })
+
+    it('getOfficesByGroup renders one Office Group\'s Offices from the accessor alone', () => {
+      const frontline = getOfficesByGroup('frontline-services')
+      expect(frontline.length).toBeGreaterThan(0)
+      expect(frontline.every(o => o.groupId === 'frontline-services')).toBe(true)
+      expect(frontline.find(o => o.id === 'civil-registry')).toBeDefined()
+    })
+
+    it('getOfficesByGroup returns empty for an unknown group', () => {
+      expect(getOfficesByGroup('ghost-group')).toEqual([])
+    })
+
+    it('getOfficeForService resolves a Certificates Service to its providedBy Office', () => {
+      const birth = getServiceBySlug('birth-certificate')
+      const office = getOfficeForService(birth!)
+      expect(office).toBeDefined()
+      expect(office!.id).toBe('civil-registry')
+    })
+
+    it('getOfficeForService returns undefined when a Service has no providedBy', () => {
+      expect(getOfficeForService({ providedBy: undefined } as never)).toBeUndefined()
+    })
+
+    it('getOfficesForCategory dedupes Offices across a Category\'s Services', () => {
+      const offices = getOfficesForCategory('certificates')
+      expect(offices.length).toBeGreaterThan(0)
+      // Three certificates Services share civil-registry; it appears once.
+      const ids = offices.map(o => o.id)
+      expect(new Set(ids).size).toBe(ids.length)
+      expect(ids).toContain('civil-registry')
+      expect(ids).toContain('barangay-hall')
+      expect(ids).toContain('police-station')
     })
   })
 
@@ -223,6 +306,148 @@ describe('configHelper', () => {
       }
       const categories = { categories: [{ id: 'certificates' }] }
       expect(validateConsistency(services, categories)).toBe(false)
+    })
+  })
+
+  describe('offices config validator', () => {
+    const minimalOfficesSchema = {
+      type: 'object',
+      required: ['officeGroups', 'offices'],
+      properties: {
+        officeGroups: {
+          type: 'array',
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['id', 'name', 'description'],
+            properties: {
+              id: { type: 'string' },
+              name: { type: 'string' },
+              description: { type: 'string' },
+              icon: { type: 'string' },
+              hidden: { type: 'boolean' },
+            },
+          },
+        },
+        offices: {
+          type: 'array',
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['id', 'name', 'groupId', 'icon', 'description', 'link'],
+            properties: {
+              id: { type: 'string' },
+              name: { type: 'string' },
+              groupId: { type: 'string' },
+              icon: { type: 'string' },
+              description: { type: 'string' },
+              link: { type: 'string' },
+              hidden: { type: 'boolean' },
+            },
+          },
+        },
+      },
+    }
+
+    function makeService(over = {}) {
+      return {
+        id: 'sample',
+        title: 'Sample',
+        description: 'A sample service',
+        category: 'Certificates & Vital Records',
+        categoryId: 'certificates',
+        keywords: ['sample'],
+        url: '/services/certificates',
+        ...over,
+      }
+    }
+
+    function makeOffices(over = {}) {
+      return {
+        officeGroups: [{ id: 'frontline-services', name: 'Frontline Services', description: 'd' }],
+        offices: [{
+          id: 'civil-registry',
+          name: 'City Civil Registry',
+          groupId: 'frontline-services',
+          icon: 'bi-building',
+          description: 'd',
+          link: '/services/certificates',
+        }],
+        ...over,
+      }
+    }
+
+    it('accepts well-formed offices data', () => {
+      const offices = makeOffices()
+      expect(validateAgainstSchema(offices, minimalOfficesSchema, 'offices')).toBe(true)
+    })
+
+    it('rejects an office missing a required field (groupId)', () => {
+      const bad = {
+        officeGroups: [{ id: 'frontline-services', name: 'F', description: 'd' }],
+        offices: [{ id: 'x', name: 'X', icon: 'bi', description: 'd', link: '/x' }],
+      }
+      expect(validateAgainstSchema(bad, minimalOfficesSchema, 'offices')).toBe(false)
+    })
+
+    it('rejects an office with an unexpected property (additionalProperties: false)', () => {
+      const bad = makeOffices({
+        offices: [{
+          id: 'civil-registry',
+          name: 'City Civil Registry',
+          groupId: 'frontline-services',
+          icon: 'bi-building',
+          description: 'd',
+          link: '/x',
+          bogus: true,
+        }],
+      })
+      expect(validateAgainstSchema(bad, minimalOfficesSchema, 'offices')).toBe(false)
+    })
+
+    it('rejects an office whose groupId references an unknown Office Group', () => {
+      const services = { services: [makeService()] }
+      const categories = { categories: [{ id: 'certificates' }] }
+      const offices = makeOffices({
+        offices: [{
+          id: 'civil-registry',
+          name: 'City Civil Registry',
+          groupId: 'ghost-group',
+          icon: 'bi-building',
+          description: 'd',
+          link: '/x',
+        }],
+      })
+      expect(validateConsistency(services, categories, offices)).toBe(false)
+    })
+
+    it('rejects duplicate office ids', () => {
+      const services = { services: [makeService()] }
+      const categories = { categories: [{ id: 'certificates' }] }
+      const office = {
+        id: 'civil-registry',
+        name: 'City Civil Registry',
+        groupId: 'frontline-services',
+        icon: 'bi-building',
+        description: 'd',
+        link: '/x',
+      }
+      const offices = makeOffices({ offices: [office, office] })
+      expect(validateConsistency(services, categories, offices)).toBe(false)
+    })
+
+    it('rejects a Service whose providedBy references an unknown Office', () => {
+      const services = { services: [makeService({ providedBy: 'ghost-office' })] }
+      const categories = { categories: [{ id: 'certificates' }] }
+      const offices = makeOffices()
+      expect(validateConsistency(services, categories, offices)).toBe(false)
+    })
+
+    it('accepts a Service whose providedBy resolves to a known Office', () => {
+      const services = { services: [makeService({ providedBy: 'civil-registry' })] }
+      const categories = { categories: [{ id: 'certificates' }] }
+      const offices = makeOffices()
+      expect(validateConsistency(services, categories, offices)).toBe(true)
     })
   })
 })

--- a/app/utils/configHelper.test.ts
+++ b/app/utils/configHelper.test.ts
@@ -185,6 +185,9 @@ describe('configHelper', () => {
     it('getOfficeBySlug returns undefined for unknown or hidden Offices', () => {
       expect(getOfficeBySlug('not-a-real-office')).toBeUndefined()
       expect(getOfficeBySlug('human-resource-management')).toBeUndefined()
+      // barangay-hall and police-station are hidden pending scoping (see #198).
+      expect(getOfficeBySlug('barangay-hall')).toBeUndefined()
+      expect(getOfficeBySlug('police-station')).toBeUndefined()
     })
 
     it('getOfficeGroups returns visible Office Groups', () => {
@@ -227,8 +230,10 @@ describe('configHelper', () => {
       const ids = offices.map(o => o.id)
       expect(new Set(ids).size).toBe(ids.length)
       expect(ids).toContain('civil-registry')
-      expect(ids).toContain('barangay-hall')
-      expect(ids).toContain('police-station')
+      // barangay-hall and police-station back Services via providedBy but are
+      // hidden pending scoping (#198), so they resolve to no card.
+      expect(ids).not.toContain('barangay-hall')
+      expect(ids).not.toContain('police-station')
     })
   })
 

--- a/app/utils/configHelper.ts
+++ b/app/utils/configHelper.ts
@@ -12,6 +12,9 @@ import type {
   NavigationConfig,
   NavigationItem,
   NewsConfig,
+  Office,
+  OfficeGroup,
+  OfficesConfig,
   OfficialsConfig,
   OgImageRouteConfig,
   SeoRouteConfig,
@@ -39,6 +42,7 @@ import hotlinesConfig from '../config/hotlines.json'
 import legislativeConfig from '../config/legislative.json'
 import navigationConfig from '../config/navigation.json'
 import newsConfig from '../config/news.json'
+import officesConfig from '../config/offices.json'
 import officialsConfig from '../config/officials.json'
 import ogImageConfig from '../config/og-image.json'
 // Import JSON config files
@@ -342,6 +346,86 @@ const CANONICAL_CATEGORY_SLUGS = new Set(['certificates'])
 
 export function isCanonicalCategory(slug: string): boolean {
   return CANONICAL_CATEGORY_SLUGS.has(slug)
+}
+
+// ---------------------------------------------------------------------------
+// Canonical Office accessor (#185).
+//
+// Office is a first-class entity that provides Services, grouped by government
+// function via Office Group. Office -> OfficeGroup is one-to-one (groupId);
+// Office <-> Category is many-to-many, mediated by the Services an Office
+// provides. Pages MUST resolve Offices through these accessors rather than
+// reading offices.json or Category.offices (which no longer exists).
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the offices config with proper typing.
+ */
+export function getOfficesConfig(): OfficesConfig {
+  return officesConfig as OfficesConfig
+}
+
+/**
+ * Get every visible Office record (hidden Offices excluded).
+ */
+export function getOffices(): Office[] {
+  return (getOfficesConfig().offices ?? []).filter(office => !office.hidden)
+}
+
+/**
+ * Get a single Office by its canonical id/slug.
+ * Returns undefined for unknown or hidden Offices.
+ */
+export function getOfficeBySlug(slug: string): Office | undefined {
+  return getOffices().find(office => office.id === slug)
+}
+
+/**
+ * Get every visible Office Group (hidden Groups excluded).
+ */
+export function getOfficeGroups(): OfficeGroup[] {
+  return (getOfficesConfig().officeGroups ?? []).filter(group => !group.hidden)
+}
+
+/**
+ * Get a single Office Group by its slug. Returns undefined for unknown/hidden.
+ */
+export function getOfficeGroupBySlug(slug: string): OfficeGroup | undefined {
+  return getOfficeGroups().find(group => group.id === slug)
+}
+
+/**
+ * Get all visible Offices belonging to a given Office Group slug.
+ */
+export function getOfficesByGroup(slug: string): Office[] {
+  return getOffices().filter(office => office.groupId === slug)
+}
+
+/**
+ * Resolve the Office that provides a given Service via its `providedBy` ref.
+ * Returns undefined when the Service has no `providedBy` or the Office is
+ * unknown/hidden.
+ */
+export function getOfficeForService(service: ServiceItem): Office | undefined {
+  return service.providedBy ? getOfficeBySlug(service.providedBy) : undefined
+}
+
+/**
+ * Get the distinct visible Offices that provide the Services in a Category.
+ * Backs the "Responsible Offices" section: Office <-> Category is many-to-many
+ * through the Services, so this dedupes Offices across the Category's Services.
+ */
+export function getOfficesForCategory(slug: string): Office[] {
+  const seen = new Set<string>()
+  const result: Office[] = []
+  for (const service of getServicesByCategory(slug)) {
+    const office = getOfficeForService(service)
+    if (office && !seen.has(office.id)) {
+      seen.add(office.id)
+      result.push(office)
+    }
+  }
+  return result
 }
 
 /**

--- a/app/utils/configHelper.ts
+++ b/app/utils/configHelper.ts
@@ -396,8 +396,12 @@ export function getOfficeGroupBySlug(slug: string): OfficeGroup | undefined {
 
 /**
  * Get all visible Offices belonging to a given Office Group slug.
+ * Returns an empty array when the Group is unknown or hidden, matching
+ * getOfficeGroupBySlug so a hidden Group never leaks its Offices.
  */
 export function getOfficesByGroup(slug: string): Office[] {
+  if (!getOfficeGroupBySlug(slug))
+    return []
   return getOffices().filter(office => office.groupId === slug)
 }
 

--- a/scripts/validate-config.mjs
+++ b/scripts/validate-config.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 // Zero-dependency config validator for the canonical Service spine (#184).
 //
-// Validates app/config/services.json and app/config/categories.json against
-// their JSON Schemas (app/config/schema/*.schema.json) using a hand-rolled,
-// minimal draft-07 subset, then runs cross-file consistency assertions that a
-// pure schema cannot express (unknown categoryId, duplicate ids, url/detail
-// coherence).
+// Validates app/config/services.json, app/config/categories.json, and
+// app/config/offices.json against their JSON Schemas (app/config/schema/*.schema.json)
+// using a hand-rolled, minimal draft-07 subset, then runs cross-file consistency
+// assertions that a pure schema cannot express (unknown categoryId/groupId,
+// duplicate ids, url/detail coherence, Service -> providedBy -> Office).
 //
 // Exit code 0 = valid; 1 = one or more violations. No runtime deps by design
 // (ADR-0001 Phase 1 stays on JSON + schema; Jan's no-new-deps guardrail).
@@ -126,6 +126,9 @@ export function validateConsistency(services, categories, offices) {
 
   const categoryIds = new Set(categoryList.map(c => c.id))
   const officeGroupIds = new Set(officeGroupList.map(g => g.id))
+  // Includes hidden Offices on purpose: a Service may reference an Office that
+  // is intentionally not yet rendered (hidden: true). The reference stays valid;
+  // getOfficeForService just resolves it to undefined so no card shows.
   const officeIds = new Set(officeList.map(o => o.id))
 
   // Duplicate office group ids

--- a/scripts/validate-config.mjs
+++ b/scripts/validate-config.mjs
@@ -117,12 +117,36 @@ export function validateAgainstSchema(data, schema, label) {
 // ---------------------------------------------------------------------------
 // Cross-file / semantic assertions.
 // ---------------------------------------------------------------------------
-export function validateConsistency(services, categories) {
+export function validateConsistency(services, categories, offices) {
   const before = errors.length
   const serviceList = services?.services ?? []
   const categoryList = categories?.categories ?? []
+  const officeGroupList = offices?.officeGroups ?? []
+  const officeList = offices?.offices ?? []
 
   const categoryIds = new Set(categoryList.map(c => c.id))
+  const officeGroupIds = new Set(officeGroupList.map(g => g.id))
+  const officeIds = new Set(officeList.map(o => o.id))
+
+  // Duplicate office group ids
+  const seenGroup = new Set()
+  for (const g of officeGroupList) {
+    if (seenGroup.has(g.id))
+      errors.push(`offices.json: duplicate office group id "${g.id}"`)
+    seenGroup.add(g.id)
+  }
+
+  // Duplicate office ids
+  const seenOffice = new Set()
+  for (const o of officeList) {
+    if (seenOffice.has(o.id))
+      errors.push(`offices.json: duplicate office id "${o.id}"`)
+    seenOffice.add(o.id)
+
+    // Every Office belongs to exactly one (known) Office Group.
+    if (!officeGroupIds.has(o.groupId))
+      errors.push(`offices.json: office "${o.id}" references unknown groupId "${o.groupId}"`)
+  }
 
   // Duplicate category ids
   const seenCat = new Set()
@@ -145,6 +169,10 @@ export function validateConsistency(services, categories) {
     if (s.categoryId && !categoryIds.has(s.categoryId))
       errors.push(`services.json: service "${s.id}" references unknown categoryId "${s.categoryId}"`)
 
+    // A providedBy ref must resolve to a known Office (Service -> Office).
+    if (s.providedBy && !officeIds.has(s.providedBy))
+      errors.push(`services.json: service "${s.id}" references unknown providedBy office "${s.providedBy}"`)
+
     // A detail-bearing Service must resolve to its own /service-details/<id>.
     // (The inverse — a no-detail Service pointing at /service-details/ — is NOT
     // an error during the transition: some details still live in TS and migrate
@@ -162,15 +190,19 @@ export function validateConsistency(services, categories) {
 function main() {
   const services = readJson(resolve(configDir, 'services.json'))
   const categories = readJson(resolve(configDir, 'categories.json'))
+  const offices = readJson(resolve(configDir, 'offices.json'))
   const servicesSchema = readJson(resolve(schemaDir, 'services.schema.json'))
   const categoriesSchema = readJson(resolve(schemaDir, 'categories.schema.json'))
+  const officesSchema = readJson(resolve(schemaDir, 'offices.schema.json'))
 
   if (services && servicesSchema)
     validateAgainstSchema(services, servicesSchema, 'services.json')
   if (categories && categoriesSchema)
     validateAgainstSchema(categories, categoriesSchema, 'categories.json')
+  if (offices && officesSchema)
+    validateAgainstSchema(offices, officesSchema, 'offices.json')
   if (services && categories)
-    validateConsistency(services, categories)
+    validateConsistency(services, categories, offices)
 
   if (errors.length > 0) {
     console.error(`\n✖ Config validation failed with ${errors.length} error(s):\n`)
@@ -180,7 +212,7 @@ function main() {
     process.exit(1)
   }
 
-  console.log('✔ Config validation passed (services.json, categories.json)')
+  console.log('✔ Config validation passed (services.json, categories.json, offices.json)')
 }
 
 // Run only when executed directly (allows importing the pure functions in tests).


### PR DESCRIPTION
## Summary

Phase-1 slice of #183 (ADR-0001): promotes **Office** to a first-class entity that *provides* Services, grouped by **Office Group** (government function), independent of the task-based **Category** taxonomy.

- New canonical source `app/config/offices.json` + `offices.schema.json` (`officeGroups` + `offices`). An Office belongs to exactly **one** Office Group via `groupId`, even when its Services span multiple Categories.
- Removed the Phase-1 stub `Category.offices` / `categoryOffice` (schema + type + data) per the #184 carry-over comment and CONTEXT.md ("Category applies to Services only, never Offices").
- Renamed the embedded service-detail office block type to `ServiceDetailOffice`, freeing `Office`/`OfficeGroup` for the first-class entity.
- Wired `Service → providedBy → Office`: Certificates Services now carry `providedBy` (civil-registry / barangay-hall / police-station).
- `configHelper` accessors: `getOffices`, `getOfficeBySlug`, `getOfficeGroups`, `getOfficeGroupBySlug`, `getOfficesByGroup`, `getOfficeForService`, `getOfficesForCategory`.
- The certificates category page's "Responsible Offices" section is repointed off `Category.offices` onto the accessor — for canonical categories it derives the distinct Offices from the Category's Services via `providedBy` (Office↔Category is many-to-many through Services). Legacy categories keep inline cards until ported.
- `pnpm validate` now schema-checks `offices.json` and enforces referential integrity: every `groupId` resolves to a known Office Group, every `providedBy` to a known Office, no duplicate ids.

## AC coverage

- **Office + Office Group modeled in schema + types; one Group per Office across Categories** — `offices.schema.json`, `Office`/`OfficeGroup` in `app/types/config.ts`; test `each Office belongs to exactly one (known) Office Group` + validator `unknown groupId` check.
- **Offices migrated out of Category into canonical source** — `offices.json` added; `Category.offices`/`categoryOffice` removed from `categories.json`, `categories.schema.json`, `config.ts`.
- **configHelper accessors for Offices + Office Groups** — the getters above; covered by `canonical Office accessor` test suite.
- **Each Service references its providing Office; Certificates resolve** — `providedBy` on `ServiceItem` + services.json; test `getOfficeForService resolves a Certificates Service to its providedBy Office`.
- **One Office Group renders its Offices via the accessor only, demoable on its own** — `getOfficesByGroup`; test `getOfficesByGroup renders one Office Group's Offices from the accessor alone`. End-to-end render proof lands on the Certificates category page via `getOfficesForCategory`. (No standalone Office-Group route added — out of scope for this data-layer tracer slice; the accessor is the demoable unit.)
- **Accessor unit tests for Offices + Office Groups against fixtures** — `app/utils/configHelper.test.ts` (`canonical Office accessor` + `offices config validator` suites).

## Quality gate

- `pnpm validate` ✅ (services.json, categories.json, offices.json)
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (54 passed)
- `pnpm build` ✅ (with `NUXT_PUBLIC_SITE_URL` set; the sitemap-prerender site-URL requirement is pre-existing env config and not part of the CI gate, which runs validate/lint/typecheck/test only)

Closes #185