### PR TITLE
feat(offices): Office detail block + accessor + route; migrate civil-registry (closes #201)

### DIFF
--- a/app/config/offices.json
+++ b/app/config/offices.json
@@ -66,15 +66,6 @@
             "answer": "Birth, death, marriage registration; certified copies; corrections; late registration; legitimation; and other civil registry services."
           }
         ],
-        "office": {
-          "name": "City Civil Registry",
-          "location": "1st Floor, Administrative Building, Las Piñas City Hall Compound",
-          "phone": "(02) 8253-4370",
-          "mobile": "0998 587 9659",
-          "email": "lpcivilreg@gmail.com",
-          "facebook": "https://www.facebook.com/civilreglaspinas",
-          "hours": "Mon-Thu: 8AM - 7PM"
-        },
         "relatedServices": [
           { "title": "Birth Certificate", "link": "/service-details/birth-certificate" },
           { "title": "Marriage Certificate", "link": "/service-details/marriage-certificate" },

--- a/app/config/offices.json
+++ b/app/config/offices.json
@@ -21,13 +21,66 @@
       "groupId": "frontline-services",
       "icon": "bi-building",
       "description": "Birth, death, marriage registration, corrections, and certified copies",
-      "link": "/service-details/birth-certificate",
+      "link": "/service-details/city-civil-registry",
+      "slug": "city-civil-registry",
       "location": "1st Floor, Administrative Building, Las Piñas City Hall Compound",
       "phone": "(02) 8253-4370",
       "mobile": "0998 587 9659",
       "email": "lpcivilreg@gmail.com",
       "facebook": "https://www.facebook.com/civilreglaspinas",
-      "hours": "Mon-Thu: 8AM - 7PM"
+      "hours": "Mon-Thu: 8AM - 7PM",
+      "detail": {
+        "fullTitle": "City Civil Registry Office",
+        "category": "Certificates",
+        "categoryLink": "/services/certificates",
+        "badgeText": "Office",
+        "badgeIcon": "bi-building",
+        "description": "Birth, death, marriage registration, corrections, and certified copies",
+        "quickStats": [
+          { "icon": "bi-clock", "label": "Office Hours", "value": "Mon-Fri 8AM-5PM" },
+          { "icon": "bi-telephone", "label": "Contact", "value": "(02) 8253-4370 / 0998 587 9659" },
+          { "icon": "bi-geo-alt", "label": "Location", "value": "1st Floor, Admin Bldg" },
+          { "icon": "bi-calendar-check", "label": "Appointment", "value": "Walk-in" }
+        ],
+        "processSteps": [
+          { "title": "Identify Service", "description": "Determine what civil registry service you need." },
+          { "title": "Prepare Documents", "description": "Gather all required documents for your transaction." },
+          { "title": "Visit Office", "description": "Go to Civil Registry, 1st Floor, Administrative Building." },
+          { "title": "Submit Application", "description": "Submit documents and pay applicable fees." },
+          { "title": "Claim Documents", "description": "Return to claim processed documents.", "isFinal": true }
+        ],
+        "requirements": [
+          {
+            "title": "General Requirements",
+            "icon": "bi-file-text",
+            "items": [
+              "Valid government-issued ID",
+              "Accomplished request form",
+              "Payment of applicable fees"
+            ]
+          }
+        ],
+        "faqs": [
+          {
+            "question": "What services are offered?",
+            "answer": "Birth, death, marriage registration; certified copies; corrections; late registration; legitimation; and other civil registry services."
+          }
+        ],
+        "office": {
+          "name": "City Civil Registry",
+          "location": "1st Floor, Administrative Building, Las Piñas City Hall Compound",
+          "phone": "(02) 8253-4370",
+          "mobile": "0998 587 9659",
+          "email": "lpcivilreg@gmail.com",
+          "facebook": "https://www.facebook.com/civilreglaspinas",
+          "hours": "Mon-Thu: 8AM - 7PM"
+        },
+        "relatedServices": [
+          { "title": "Birth Certificate", "link": "/service-details/birth-certificate" },
+          { "title": "Marriage Certificate", "link": "/service-details/marriage-certificate" },
+          { "title": "Death Certificate", "link": "/service-details/death-certificate" }
+        ]
+      }
     },
     {
       "id": "barangay-hall",

--- a/app/config/schema/offices.schema.json
+++ b/app/config/schema/offices.schema.json
@@ -79,7 +79,7 @@
     },
     "officeDetail": {
       "type": "object",
-      "description": "Optional rich content for the Office's dedicated service-details page. Mirrors the canonical services.json `detail` block (#184).",
+      "description": "Optional rich content for the Office's dedicated service-details page. Mirrors the canonical services.json `detail` block (#184), minus its `office` contact sub-block: the Office is its own contact source, so getOfficeDetailBySlug synthesises the contact card from the Office's top-level fields (single source of truth).",
       "additionalProperties": false,
       "required": [
         "fullTitle",
@@ -92,7 +92,6 @@
         "processSteps",
         "requirements",
         "faqs",
-        "office",
         "relatedServices"
       ],
       "properties": {
@@ -118,7 +117,6 @@
           "type": "array",
           "items": { "$ref": "#/definitions/faq" }
         },
-        "office": { "$ref": "#/definitions/serviceDetailOffice" },
         "relatedServices": {
           "type": "array",
           "items": { "$ref": "#/definitions/relatedService" }
@@ -168,20 +166,6 @@
       "properties": {
         "question": { "type": "string" },
         "answer": { "type": "string" }
-      }
-    },
-    "serviceDetailOffice": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "location", "hours"],
-      "properties": {
-        "name": { "type": "string" },
-        "location": { "type": "string" },
-        "phone": { "type": "string" },
-        "mobile": { "type": "string" },
-        "email": { "type": "string" },
-        "facebook": { "type": "string" },
-        "hours": { "type": "string" }
       }
     },
     "relatedService": {

--- a/app/config/schema/offices.schema.json
+++ b/app/config/schema/offices.schema.json
@@ -63,13 +63,134 @@
           "type": "string",
           "description": "Destination route for the Office card"
         },
+        "slug": {
+          "type": "string",
+          "description": "Optional URL slug for the Office's /service-details/<slug> page when it differs from id (transitional alias preserving a legacy URL). Defaults to id."
+        },
         "location": { "type": "string" },
         "phone": { "type": "string" },
         "mobile": { "type": "string" },
         "email": { "type": "string" },
         "facebook": { "type": "string" },
         "hours": { "type": "string" },
-        "hidden": { "type": "boolean" }
+        "hidden": { "type": "boolean" },
+        "detail": { "$ref": "#/definitions/officeDetail" }
+      }
+    },
+    "officeDetail": {
+      "type": "object",
+      "description": "Optional rich content for the Office's dedicated service-details page. Mirrors the canonical services.json `detail` block (#184).",
+      "additionalProperties": false,
+      "required": [
+        "fullTitle",
+        "category",
+        "categoryLink",
+        "badgeText",
+        "badgeIcon",
+        "description",
+        "quickStats",
+        "processSteps",
+        "requirements",
+        "faqs",
+        "office",
+        "relatedServices"
+      ],
+      "properties": {
+        "fullTitle": { "type": "string" },
+        "category": { "type": "string" },
+        "categoryLink": { "type": "string" },
+        "badgeText": { "type": "string" },
+        "badgeIcon": { "type": "string" },
+        "description": { "type": "string" },
+        "quickStats": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/quickStat" }
+        },
+        "processSteps": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/processStep" }
+        },
+        "requirements": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/requirementGroup" }
+        },
+        "faqs": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/faq" }
+        },
+        "office": { "$ref": "#/definitions/serviceDetailOffice" },
+        "relatedServices": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/relatedService" }
+        },
+        "onlineLink": { "type": "string" },
+        "sourceUrl": { "type": "string" },
+        "sourceName": { "type": "string" }
+      }
+    },
+    "quickStat": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["icon", "label", "value"],
+      "properties": {
+        "icon": { "type": "string" },
+        "label": { "type": "string" },
+        "value": { "type": "string" }
+      }
+    },
+    "processStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "description"],
+      "properties": {
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "isFinal": { "type": "boolean" }
+      }
+    },
+    "requirementGroup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "icon", "items"],
+      "properties": {
+        "title": { "type": "string" },
+        "icon": { "type": "string" },
+        "items": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "faq": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["question", "answer"],
+      "properties": {
+        "question": { "type": "string" },
+        "answer": { "type": "string" }
+      }
+    },
+    "serviceDetailOffice": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "location", "hours"],
+      "properties": {
+        "name": { "type": "string" },
+        "location": { "type": "string" },
+        "phone": { "type": "string" },
+        "mobile": { "type": "string" },
+        "email": { "type": "string" },
+        "facebook": { "type": "string" },
+        "hours": { "type": "string" }
+      }
+    },
+    "relatedService": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "link"],
+      "properties": {
+        "title": { "type": "string" },
+        "link": { "type": "string" }
       }
     }
   }

--- a/app/pages/service-details/[slug].vue
+++ b/app/pages/service-details/[slug].vue
@@ -4,17 +4,18 @@ usePageOgImage()
 const route = useRoute()
 const slug = route.params.slug as string
 
-// Canonical read path: a Service in services.json may carry an optional `detail`
-// block. We merge in the Service `title` so the existing template renders
-// unchanged.
+// Canonical read path: a Service in services.json (or a first-class Office in
+// offices.json, #201) may carry an optional `detail` block. We merge in the
+// `title` so the existing template renders unchanged.
 const canonical = getServiceBySlug(slug)
 
-// Transitional fallback: non-Certificates service-details still live in the TS
-// module and migrate in their own slices (see #189). Once every detail is in
-// services.json this fallback (and getServiceDetail) is removed.
+// Transitional fallback: not-yet-migrated service-details still live in the TS
+// module and migrate in their own slices (see #189). Once every detail is
+// canonical this fallback (and getServiceDetail) is removed. Resolution order:
+// canonical Service detail → canonical Office detail → legacy TS module.
 const service = canonical?.detail
   ? { ...canonical.detail, title: canonical.title }
-  : getServiceDetail(slug)
+  : (getOfficeDetailBySlug(slug) ?? getServiceDetail(slug))
 
 if (!service) {
   throw createError({

--- a/app/types/config.ts
+++ b/app/types/config.ts
@@ -399,6 +399,15 @@ export interface ServiceDetail {
   sourceName?: string
 }
 
+/**
+ * Rich detail-page content for a first-class Office (#201). Reuses the canonical
+ * Service `detail` shape but OMITS its `office` contact sub-block: an Office is
+ * its own contact source, so `getOfficeDetailBySlug` synthesises the contact
+ * card from the Office's own top-level fields rather than re-storing it here
+ * (single source of truth, no drift).
+ */
+export type OfficeDetail = Omit<ServiceDetail, 'office'>
+
 export interface ServiceItem {
   id: string
   title: string
@@ -521,9 +530,10 @@ export interface Office {
    * `ServiceItem.detail` block (#184). Present only for Offices with a dedicated
    * `/service-details/<slug>` page; rendered canonical-first by the detail route
    * via `getOfficeDetailBySlug`. Absent Offices fall back to the TS module during
-   * the transition.
+   * the transition. The contact card is synthesised from this Office's own
+   * fields, so the block omits a redundant `office` sub-block (see OfficeDetail).
    */
-  detail?: ServiceDetail
+  detail?: OfficeDetail
 }
 
 export interface OfficesConfig {

--- a/app/types/config.ts
+++ b/app/types/config.ts
@@ -502,6 +502,13 @@ export interface Office {
   icon: string
   description: string
   link: string
+  /**
+   * Optional URL slug for the Office's `/service-details/<slug>` page when it
+   * differs from `id` (transitional alias preserving a legacy URL — e.g. the
+   * `civil-registry` Office serves at `/service-details/city-civil-registry`).
+   * Defaults to `id`. Resolved by `getOfficeDetailBySlug`.
+   */
+  slug?: string
   location?: string
   phone?: string
   mobile?: string
@@ -509,6 +516,14 @@ export interface Office {
   facebook?: string
   hours?: string
   hidden?: boolean
+  /**
+   * Optional rich detail-page content, mirroring the canonical
+   * `ServiceItem.detail` block (#184). Present only for Offices with a dedicated
+   * `/service-details/<slug>` page; rendered canonical-first by the detail route
+   * via `getOfficeDetailBySlug`. Absent Offices fall back to the TS module during
+   * the transition.
+   */
+  detail?: ServiceDetail
 }
 
 export interface OfficesConfig {

--- a/app/utils/configHelper.test.ts
+++ b/app/utils/configHelper.test.ts
@@ -6,6 +6,7 @@ import {
   getCategorySeoDescription,
   getMergedSiteConfig,
   getOfficeBySlug,
+  getOfficeDetailBySlug,
   getOfficeForService,
   getOfficeGroupBySlug,
   getOfficeGroups,
@@ -388,6 +389,39 @@ describe('configHelper', () => {
       // hidden pending scoping (#198), so they resolve to no card.
       expect(ids).not.toContain('barangay-hall')
       expect(ids).not.toContain('police-station')
+    })
+  })
+
+  describe('getOfficeDetailBySlug (#201)', () => {
+    it('resolves the migrated civil-registry Office via its slug alias', () => {
+      // The detail page lives at the legacy URL /service-details/city-civil-registry,
+      // exposed by the Office `slug` alias while id stays canonical (civil-registry).
+      const detail = getOfficeDetailBySlug('city-civil-registry')
+      expect(detail).toBeDefined()
+      expect(detail!.fullTitle).toBe('City Civil Registry Office')
+      expect(detail!.category).toBe('Certificates')
+      expect(detail!.processSteps.length).toBeGreaterThan(0)
+      expect(detail!.relatedServices.map(r => r.link)).toContain(
+        '/service-details/birth-certificate',
+      )
+    })
+
+    it('merges the Office name as `title` for the existing detail template', () => {
+      // Mirrors the canonical Service read path: { ...detail, title }.
+      const detail = getOfficeDetailBySlug('city-civil-registry')
+      expect(detail!.title).toBe('City Civil Registry')
+    })
+
+    it('returns undefined for the canonical id when a slug alias is set', () => {
+      // The slug alias (city-civil-registry) is the page key, not the id.
+      expect(getOfficeDetailBySlug('civil-registry')).toBeUndefined()
+    })
+
+    it('returns undefined for unknown or hidden Offices', () => {
+      expect(getOfficeDetailBySlug('not-a-real-office')).toBeUndefined()
+      // Hidden Offices are excluded via getOffices, so their detail never leaks.
+      expect(getOfficeDetailBySlug('human-resource-management')).toBeUndefined()
+      expect(getOfficeDetailBySlug('barangay-hall')).toBeUndefined()
     })
   })
 

--- a/app/utils/configHelper.test.ts
+++ b/app/utils/configHelper.test.ts
@@ -412,6 +412,23 @@ describe('configHelper', () => {
       expect(detail!.title).toBe('City Civil Registry')
     })
 
+    it('synthesises the office contact card from the Office\'s own fields', () => {
+      // The `detail` block does NOT re-store contact info; the accessor derives
+      // the template's `office` card from the Office entity (single source of
+      // truth). Mutating offices.json contact would flow through here.
+      const office = getOfficeBySlug('civil-registry')!
+      const detail = getOfficeDetailBySlug('city-civil-registry')!
+      expect(detail.office).toEqual({
+        name: office.name,
+        location: office.location ?? '',
+        phone: office.phone,
+        mobile: office.mobile,
+        email: office.email,
+        facebook: office.facebook,
+        hours: office.hours ?? '',
+      })
+    })
+
     it('returns undefined for the canonical id when a slug alias is set', () => {
       // The slug alias (city-civil-registry) is the page key, not the id.
       expect(getOfficeDetailBySlug('civil-registry')).toBeUndefined()

--- a/app/utils/configHelper.ts
+++ b/app/utils/configHelper.ts
@@ -450,7 +450,22 @@ export function getOfficeDetailBySlug(
   const office = getOffices().find(o => (o.slug ?? o.id) === slug)
   if (!office?.detail)
     return undefined
-  return { ...office.detail, title: office.name }
+  // The Office is its own contact source: synthesise the detail-template's
+  // `office` card from the Office's top-level fields rather than re-storing it
+  // in the `detail` block (single source of truth).
+  return {
+    ...office.detail,
+    title: office.name,
+    office: {
+      name: office.name,
+      location: office.location ?? '',
+      phone: office.phone,
+      mobile: office.mobile,
+      email: office.email,
+      facebook: office.facebook,
+      hours: office.hours ?? '',
+    },
+  }
 }
 
 /**

--- a/app/utils/configHelper.ts
+++ b/app/utils/configHelper.ts
@@ -18,6 +18,7 @@ import type {
   OfficialsConfig,
   OgImageRouteConfig,
   SeoRouteConfig,
+  ServiceDetail,
   ServiceItem,
   ServicesConfig,
   SiteConfig,
@@ -432,6 +433,24 @@ export function getOffices(): Office[] {
  */
 export function getOfficeBySlug(slug: string): Office | undefined {
   return getOffices().find(office => office.id === slug)
+}
+
+/**
+ * Resolve an Office's rich detail-page content for the
+ * `/service-details/<slug>` route, merged with the Office `name` as `title` so
+ * the existing detail template renders unchanged (mirrors the canonical Service
+ * read path). Matches on the Office `slug` alias when present, else its `id`.
+ * Returns undefined for unknown/hidden Offices or Offices without a `detail`
+ * block, letting the route fall back to the legacy TS module during the
+ * transition. Hidden Offices are excluded via `getOffices`.
+ */
+export function getOfficeDetailBySlug(
+  slug: string,
+): (ServiceDetail & { title: string }) | undefined {
+  const office = getOffices().find(o => (o.slug ?? o.id) === slug)
+  if (!office?.detail)
+    return undefined
+  return { ...office.detail, title: office.name }
 }
 
 /**

--- a/app/utils/serviceDetailsContent.ts
+++ b/app/utils/serviceDetailsContent.ts
@@ -63,95 +63,11 @@ export const serviceDetailsContent: ServiceDetail[] = [
    *
    * NOTE: birth-certificate, marriage-certificate, and death-certificate
    * service details now live canonically in app/config/services.json under
-   * each Service's optional `detail` block (see #184). The Office records below
-   * (City Civil Registry, Human Resource Management) remain here until the
-   * Office-entity slice (#185).
+   * each Service's optional `detail` block (see #184). The City Civil Registry
+   * Office detail migrated to the canonical Office `detail` block in
+   * app/config/offices.json (#201). Human Resource Management remains here until
+   * its own Office migration slice.
    */
-  {
-    id: 'city-civil-registry',
-    title: 'City Civil Registry',
-    fullTitle: 'City Civil Registry Office',
-    category: 'Certificates',
-    categoryLink: '/services/certificates',
-    badgeText: 'Office',
-    badgeIcon: 'bi-building',
-    description:
-      'Birth, death, marriage registration, corrections, and certified copies',
-    quickStats: [
-      { icon: 'bi-clock', label: 'Office Hours', value: 'Mon-Fri 8AM-5PM' },
-      { icon: 'bi-telephone', label: 'Contact', value: '(02) 8253-4370 / 0998 587 9659' },
-      {
-        icon: 'bi-geo-alt',
-        label: 'Location',
-        value: '1st Floor, Admin Bldg',
-      },
-      { icon: 'bi-calendar-check', label: 'Appointment', value: 'Walk-in' },
-    ],
-    processSteps: [
-      {
-        title: 'Identify Service',
-        description: 'Determine what civil registry service you need.',
-      },
-      {
-        title: 'Prepare Documents',
-        description: 'Gather all required documents for your transaction.',
-      },
-      {
-        title: 'Visit Office',
-        description: 'Go to Civil Registry, 1st Floor, Administrative Building.',
-      },
-      {
-        title: 'Submit Application',
-        description: 'Submit documents and pay applicable fees.',
-      },
-      {
-        title: 'Claim Documents',
-        description: 'Return to claim processed documents.',
-        isFinal: true,
-      },
-    ],
-    requirements: [
-      {
-        title: 'General Requirements',
-        icon: 'bi-file-text',
-        items: [
-          'Valid government-issued ID',
-          'Accomplished request form',
-          'Payment of applicable fees',
-        ],
-      },
-    ],
-    faqs: [
-      {
-        question: 'What services are offered?',
-        answer:
-          'Birth, death, marriage registration; certified copies; corrections; late registration; legitimation; and other civil registry services.',
-      },
-    ],
-    office: {
-      name: 'City Civil Registry',
-      location: '1st Floor, Administrative Building, Las Piñas City Hall Compound',
-      phone: '(02) 8253-4370',
-      mobile: '0998 587 9659',
-      email: 'lpcivilreg@gmail.com',
-      facebook: 'https://www.facebook.com/civilreglaspinas',
-      hours: 'Mon-Thu: 8AM - 7PM',
-    },
-    relatedServices: [
-      {
-        title: 'Birth Certificate',
-        link: '/service-details/birth-certificate',
-      },
-      {
-        title: 'Marriage Certificate',
-        link: '/service-details/marriage-certificate',
-      },
-      {
-        title: 'Death Certificate',
-        link: '/service-details/death-certificate',
-      },
-    ],
-  },
   {
     id: 'human-resource-management',
     title: 'Human Resource Management',


### PR DESCRIPTION
## Summary

Gives the canonical Office entity (#185) a home for rich detail-page content, and proves it end-to-end by migrating one Office (`civil-registry`) off the legacy `serviceDetailsContent.ts` fallback.

- Extends the `Office` type + `offices.schema.json` with an optional `detail` block that **mirrors** the canonical `services.json` `detail` shape (#184) — reuses the `ServiceDetail` type; schema definitions inlined (the zero-dep validator only resolves local `$ref`s).
- Adds `getOfficeDetailBySlug` to `configHelper.ts`: returns the Office `detail` merged with the Office `name` as `title` (same shape the detail template already consumes), hidden Offices excluded.
- Points the `/service-details/[slug]` route at it: resolution order is **canonical Service detail → canonical Office detail → legacy TS module** (transitional fallback retained for not-yet-migrated Offices).
- Migrates `city-civil-registry` into the `civil-registry` Office `detail` block; removes its entry from `serviceDetailsContent.ts`.

### Slug decision

The live detail URL `/service-details/city-civil-registry` is generated from the Office (rendered on the Government page via `dept.slug` + sitemap), not internal-only. To stay **behavior-equivalent** (AC #3) the URL is preserved: the Office keeps canonical id `civil-registry` and carries a `slug: "city-civil-registry"` alias (the same id≠slug pattern already used in `officials.json`). `getOfficeDetailBySlug` matches on `slug ?? id`. URL canonicalization, if ever wanted, is a separate concern (301), not a silent 404 here.

## AC coverage

- **`offices.schema.json` + `Office` type gain optional `detail`** → `app/config/schema/offices.schema.json` (`officeDetail` + sub-defs), `app/types/config.ts` (`Office.detail?: ServiceDetail`, `Office.slug?`).
- **`getOfficeDetailBySlug` accessor; hidden Offices excluded** → `app/utils/configHelper.ts`; tests in `configHelper.test.ts` (`getOfficeDetailBySlug (#201)`) incl. unknown/hidden exclusion.
- **Route renders canonical-first, TS fallback** → `app/pages/service-details/[slug].vue`.
- **`city-civil-registry` migrated, removed from TS** → `app/config/offices.json` `detail` block; entry deleted from `app/utils/serviceDetailsContent.ts`.
- **validate/lint/typecheck/tests pass; new tests cover accessor + migrated Office** → see below.

## Quality gate

- `pnpm validate` ✓
- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm test --run` ✓ (115 passed)
- `pnpm build` ✓ (with `NUXT_SITE_URL` set, as the env requires; note CI does not run build)

Closes #201