### PR TITLE
refactor(services): derive service-details Office card from providedBy (closes #212)

### DIFF
--- a/app/config/offices.json
+++ b/app/config/offices.json
@@ -140,7 +140,7 @@
     },
     {
       "id": "cswdo",
-      "name": "City Social Welfare & Development Office",
+      "name": "City Social Welfare & Development Office (CSWDO)",
       "groupId": "frontline-services",
       "icon": "bi-people",
       "description": "Social welfare programs, indigency certificates, AICS, PWD and senior citizen assistance",
@@ -204,7 +204,7 @@
     },
     {
       "id": "cdrrmo",
-      "name": "City Disaster Risk Reduction & Management Office",
+      "name": "City Disaster Risk Reduction & Management Office (CDRRMO)",
       "groupId": "frontline-services",
       "icon": "bi-shield-exclamation",
       "description": "24/7 emergency response, rescue operations, and disaster preparedness programs",

--- a/app/config/schema/services.schema.json
+++ b/app/config/schema/services.schema.json
@@ -83,7 +83,6 @@
         "processSteps",
         "requirements",
         "faqs",
-        "office",
         "relatedServices"
       ],
       "properties": {

--- a/app/config/services.json
+++ b/app/config/services.json
@@ -117,15 +117,6 @@
             "answer": "Both are certified true copies. PSA copies are nationally-recognized and required for passport/visa applications. Local copies are accepted for most local transactions and school enrollment."
           }
         ],
-        "office": {
-          "name": "City Civil Registry",
-          "location": "1st Floor, Administrative Building, Las Piñas City Hall Compound",
-          "phone": "(02) 8253-4370",
-          "mobile": "0998 587 9659",
-          "email": "lpcivilreg@gmail.com",
-          "facebook": "https://www.facebook.com/civilreglaspinas",
-          "hours": "Mon-Thu: 8AM - 7PM"
-        },
         "relatedServices": [
           {
             "title": "Marriage Certificate",
@@ -262,15 +253,6 @@
             "answer": "Only marriages registered in this city are available. Request from the city where you were married or from PSA."
           }
         ],
-        "office": {
-          "name": "City Civil Registry",
-          "location": "1st Floor, Administrative Building, Las Piñas City Hall Compound",
-          "phone": "(02) 8253-4370",
-          "mobile": "0998 587 9659",
-          "email": "lpcivilreg@gmail.com",
-          "facebook": "https://www.facebook.com/civilreglaspinas",
-          "hours": "Mon-Thu: 8AM - 7PM"
-        },
         "relatedServices": [
           {
             "title": "Birth Certificate",
@@ -393,15 +375,6 @@
             "answer": "Evaluator shall prepare documents for posting within 10 days, and the release of Certified True Copy is expiration of 10 days posting period."
           }
         ],
-        "office": {
-          "name": "City Civil Registry",
-          "location": "1st Floor, Administrative Building, Las Piñas City Hall Compound",
-          "phone": "(02) 8253-4370",
-          "mobile": "0998 587 9659",
-          "email": "lpcivilreg@gmail.com",
-          "facebook": "https://www.facebook.com/civilreglaspinas",
-          "hours": "Mon-Thu: 8AM - 7PM"
-        },
         "relatedServices": [
           {
             "title": "Birth Certificate",
@@ -1524,14 +1497,6 @@
             "answer": "Yes, all vaccines provided are DOH-approved and safe."
           }
         ],
-        "office": {
-          "name": "City Health Office",
-          "location": "City Hall Compound, Las Piñas City",
-          "phone": "(02) 8367-3406",
-          "mobile": "0998 977 8597",
-          "facebook": "https://www.facebook.com/LPCityhealth",
-          "hours": "Mon-Fri: 8AM - 5PM"
-        },
         "relatedServices": []
       }
     },
@@ -1851,12 +1816,6 @@
             "answer": "Yes, for emergency cases within the city."
           }
         ],
-        "office": {
-          "name": "CDRRMO",
-          "location": "Command Center, Las Piñas City",
-          "phone": "(02) 8290-6500",
-          "hours": "24/7 Operations"
-        },
         "relatedServices": []
       }
     },
@@ -2029,12 +1988,6 @@
             "answer": "Indigent families and individuals in crisis situations."
           }
         ],
-        "office": {
-          "name": "CSWDO",
-          "location": "City Hall, Ground Floor, Las Piñas City Hall Compound",
-          "phone": "0916 284 0885",
-          "hours": "Mon-Thu: 8AM - 7PM"
-        },
         "relatedServices": [
           {
             "title": "Senior Citizen Services",
@@ -2258,12 +2211,6 @@
             "answer": "Usually 0.5% to 0.75% of the selling price or zonal value, whichever is higher."
           }
         ],
-        "office": {
-          "name": "City Assessor's Office",
-          "location": "City Hall, Ground Floor, Las Piñas City Hall Compound",
-          "phone": "(078) 326-5001",
-          "hours": "Mon-Thu: 8AM - 7PM"
-        },
         "relatedServices": []
       }
     },

--- a/app/pages/service-details/[slug].vue
+++ b/app/pages/service-details/[slug].vue
@@ -25,6 +25,16 @@ if (!service) {
   })
 }
 
+// Single-source the "Office Information" card off the providing Office via
+// `providedBy` (mirrors getOfficeForService) so it can never drift from the
+// canonical Office. getServiceOfficeCard falls back to the Service's inline
+// free-text `detail.office` for providers not yet first-class Offices (e.g.
+// BPLO business services). The office-detail / legacy-module paths already
+// synthesise/carry their own `office`, so reuse it directly.
+const officeInfo = canonical?.detail
+  ? getServiceOfficeCard(canonical)
+  : service.office
+
 const openFaq = ref<number | null>(null)
 
 const { lguName } = useConfig()
@@ -243,30 +253,30 @@ function toggleFaq(index: number) {
 
           <!-- Sidebar -->
           <div class="space-y-4">
-            <UiCard>
+            <UiCard v-if="officeInfo">
               <h4 class="font-semibold text-gray-900 mb-4 flex items-center gap-2">
                 <i class="bi bi-building text-primary-600" /> Office Information
               </h4>
               <p class="font-medium text-gray-900">
-                {{ service.office.name }}
+                {{ officeInfo.name }}
               </p>
               <p class="text-sm text-gray-600 mt-2">
-                {{ service.office.location }}
+                {{ officeInfo.location }}
               </p>
-              <p v-if="service.office.phone" class="text-sm text-gray-600 mt-1 flex items-center gap-2">
-                <i class="bi bi-telephone" /> {{ service.office.phone }}
+              <p v-if="officeInfo.phone" class="text-sm text-gray-600 mt-1 flex items-center gap-2">
+                <i class="bi bi-telephone" /> {{ officeInfo.phone }}
               </p>
-              <p v-if="service.office.mobile" class="text-sm text-gray-600 mt-1 flex items-center gap-2">
-                <i class="bi bi-phone" /> {{ service.office.mobile }}
+              <p v-if="officeInfo.mobile" class="text-sm text-gray-600 mt-1 flex items-center gap-2">
+                <i class="bi bi-phone" /> {{ officeInfo.mobile }}
               </p>
-              <p v-if="service.office.email" class="text-sm text-gray-600 mt-1 flex items-center gap-2">
-                <i class="bi bi-envelope" /> <a :href="`mailto:${service.office.email}`" class="hover:underline text-primary-600">{{ service.office.email }}</a>
+              <p v-if="officeInfo.email" class="text-sm text-gray-600 mt-1 flex items-center gap-2">
+                <i class="bi bi-envelope" /> <a :href="`mailto:${officeInfo.email}`" class="hover:underline text-primary-600">{{ officeInfo.email }}</a>
               </p>
-              <p v-if="service.office.facebook" class="text-sm text-gray-600 mt-1 flex items-center gap-2">
-                <i class="bi bi-facebook" /> <a :href="service.office.facebook" target="_blank" rel="noopener noreferrer" class="hover:underline text-primary-600">Facebook Page</a>
+              <p v-if="officeInfo.facebook" class="text-sm text-gray-600 mt-1 flex items-center gap-2">
+                <i class="bi bi-facebook" /> <a :href="officeInfo.facebook" target="_blank" rel="noopener noreferrer" class="hover:underline text-primary-600">Facebook Page</a>
               </p>
               <p class="text-sm text-gray-600 mt-1 flex items-center gap-2">
-                <i class="bi bi-clock" /> {{ service.office.hours }}
+                <i class="bi bi-clock" /> {{ officeInfo.hours }}
               </p>
             </UiCard>
 

--- a/app/pages/service-details/[slug].vue
+++ b/app/pages/service-details/[slug].vue
@@ -30,7 +30,8 @@ if (!service) {
 // canonical Office. getServiceOfficeCard falls back to the Service's inline
 // free-text `detail.office` for providers not yet first-class Offices (e.g.
 // BPLO business services). The office-detail / legacy-module paths already
-// synthesise/carry their own `office`, so reuse it directly.
+// synthesise/carry their own `office`, so reuse it directly. `detail.office` is
+// now optional, so officeInfo may be undefined — the card is `v-if`-guarded.
 const officeInfo = canonical?.detail
   ? getServiceOfficeCard(canonical)
   : service.office
@@ -275,7 +276,7 @@ function toggleFaq(index: number) {
               <p v-if="officeInfo.facebook" class="text-sm text-gray-600 mt-1 flex items-center gap-2">
                 <i class="bi bi-facebook" /> <a :href="officeInfo.facebook" target="_blank" rel="noopener noreferrer" class="hover:underline text-primary-600">Facebook Page</a>
               </p>
-              <p class="text-sm text-gray-600 mt-1 flex items-center gap-2">
+              <p v-if="officeInfo.hours" class="text-sm text-gray-600 mt-1 flex items-center gap-2">
                 <i class="bi bi-clock" /> {{ officeInfo.hours }}
               </p>
             </UiCard>

--- a/app/types/config.ts
+++ b/app/types/config.ts
@@ -365,6 +365,11 @@ export interface Faq {
  * Office-contact block embedded in a Service's `detail` (the "Office
  * Information" card on a /service-details page). This is NOT the first-class
  * Office entity — see `Office` / `OfficeGroup` below and offices.json.
+ *
+ * Only present (as free text) for Services whose provider is NOT yet a
+ * first-class Office (e.g. BPLO business services with no `providedBy`).
+ * providedBy-backed Services derive the card from their canonical Office via
+ * `getServiceOfficeCard`, so they carry no inline copy (#212, single source).
  */
 export interface ServiceDetailOffice {
   name: string
@@ -392,7 +397,7 @@ export interface ServiceDetail {
   processSteps: ProcessStep[]
   requirements: RequirementGroup[]
   faqs: Faq[]
-  office: ServiceDetailOffice
+  office?: ServiceDetailOffice
   relatedServices: RelatedService[]
   onlineLink?: string
   sourceUrl?: string

--- a/app/utils/configHelper.test.ts
+++ b/app/utils/configHelper.test.ts
@@ -6,6 +6,7 @@ import {
   getCategorySeoDescription,
   getMergedSiteConfig,
   getOfficeBySlug,
+  getOfficeContactCard,
   getOfficeDetailBySlug,
   getOfficeForService,
   getOfficeGroupBySlug,
@@ -17,6 +18,7 @@ import {
   getOgImageRouteConfig,
   getServiceBySlug,
   getServiceCategories,
+  getServiceOfficeCard,
   getServicesByCategory,
   getServiceSeoDescription,
   getSiteConfig,
@@ -534,16 +536,13 @@ describe('configHelper', () => {
       expect(relatedLinks.some(l => l.startsWith('/offices/'))).toBe(false)
     })
 
-    it('every detail.office.location matches its providedBy Office (no drift)', () => {
-      // The inline detail.office copy must not diverge from the canonical Office
-      // it is providedBy. Guards the whole class, not just the migrated Services.
+    it('no providedBy-backed Service carries an inline detail.office (#212)', () => {
+      // The inline copy is gone: a Service with a first-class providing Office
+      // single-sources its contact card off that Office, never a stored copy.
       for (const service of getAllServices()) {
-        if (!service.detail?.office || !service.providedBy)
+        if (!service.providedBy || !getOfficeBySlug(service.providedBy))
           continue
-        const office = getOfficeBySlug(service.providedBy)
-        if (!office)
-          continue
-        expect(service.detail.office.location, service.id).toBe(office.location)
+        expect(service.detail?.office, service.id).toBeUndefined()
       }
     })
 
@@ -583,6 +582,61 @@ describe('configHelper', () => {
       for (const id of MIGRATED_ADMIN) {
         expect(ids, id).toContain(id)
       }
+    })
+  })
+
+  describe('service-details Office card derivation (#212)', () => {
+    it('getOfficeContactCard synthesises the card from the Office\'s own fields', () => {
+      const office = getOfficeBySlug('civil-registry')!
+      const card = getOfficeContactCard(office)
+      expect(card).toEqual({
+        name: office.name,
+        location: office.location ?? '',
+        phone: office.phone,
+        mobile: office.mobile,
+        email: office.email,
+        facebook: office.facebook,
+        hours: office.hours ?? '',
+      })
+    })
+
+    it('getServiceOfficeCard derives a providedBy Service\'s card straight from its Office (no drift possible)', () => {
+      // The card is read from the canonical Office entity, NOT from any inline
+      // copy on the Service. By construction it cannot diverge from the Office
+      // page, which renders the same getOfficeContactCard output.
+      for (const service of getAllServices()) {
+        const office = getOfficeForService(service)
+        if (!office)
+          continue
+        const card = getServiceOfficeCard(service)
+        expect(card, service.id).toEqual(getOfficeContactCard(office))
+        // And it reflects the live Office fields, not a stored value.
+        expect(card!.name, service.id).toBe(office.name)
+        expect(card!.location, service.id).toBe(office.location ?? '')
+        expect(card!.hours, service.id).toBe(office.hours ?? '')
+      }
+    })
+
+    it('birth-certificate renders the civil-registry Office card via providedBy', () => {
+      const birth = getServiceBySlug('birth-certificate')!
+      expect(birth.detail?.office).toBeUndefined()
+      const office = getOfficeBySlug('civil-registry')!
+      expect(getServiceOfficeCard(birth)).toEqual(getOfficeContactCard(office))
+    })
+
+    it('falls back to the inline free-text office for a providerless Service', () => {
+      // BPLO business services have no first-class Office yet: the card comes
+      // from the Service's inline detail.office.
+      const biz = getServiceBySlug('business-permit-new')!
+      expect(biz.providedBy).toBeUndefined()
+      expect(getOfficeForService(biz)).toBeUndefined()
+      const card = getServiceOfficeCard(biz)
+      expect(card).toBeDefined()
+      expect(card).toEqual(biz.detail?.office)
+    })
+
+    it('returns undefined when a Service has neither a providing Office nor an inline office', () => {
+      expect(getServiceOfficeCard({ providedBy: undefined } as never)).toBeUndefined()
     })
   })
 

--- a/app/utils/configHelper.ts
+++ b/app/utils/configHelper.ts
@@ -19,6 +19,7 @@ import type {
   OgImageRouteConfig,
   SeoRouteConfig,
   ServiceDetail,
+  ServiceDetailOffice,
   ServiceItem,
   ServicesConfig,
   SiteConfig,
@@ -457,16 +458,42 @@ export function getOfficeDetailBySlug(
   return {
     ...office.detail,
     title: office.name,
-    office: {
-      name: office.name,
-      location: office.location ?? '',
-      phone: office.phone,
-      mobile: office.mobile,
-      email: office.email,
-      facebook: office.facebook,
-      hours: office.hours ?? '',
-    },
+    office: getOfficeContactCard(office),
   }
+}
+
+/**
+ * Synthesise the detail-page "Office Information" card from a first-class
+ * Office's own top-level fields. The Office entity is the single source of
+ * truth for contact data — this never reads an inline `detail.office` copy, so
+ * no drift between a Service/Office page and its canonical Office is possible.
+ */
+export function getOfficeContactCard(office: Office): ServiceDetailOffice {
+  return {
+    name: office.name,
+    location: office.location ?? '',
+    phone: office.phone,
+    mobile: office.mobile,
+    email: office.email,
+    facebook: office.facebook,
+    hours: office.hours ?? '',
+  }
+}
+
+/**
+ * Resolve the "Office Information" card for a /service-details/<slug> page.
+ * Single-sources off the providing Office when the Service has `providedBy`
+ * (mirrors getOfficeForService); otherwise falls back to the Service's inline
+ * free-text `detail.office` for providers not yet first-class Offices (e.g.
+ * BPLO business services). Returns undefined when neither resolves.
+ */
+export function getServiceOfficeCard(
+  service: ServiceItem,
+): ServiceDetailOffice | undefined {
+  const office = getOfficeForService(service)
+  if (office)
+    return getOfficeContactCard(office)
+  return service.detail?.office
 }
 
 /**


### PR DESCRIPTION
## Summary
The `/service-details/<slug>` "Office Information" card read `service.detail.office` — an inline copy of the providing Office's contact data on every detail-bearing Service. That duplicated the canonical Office entity (`offices.json`) and drifted from it (PR #211 hand-fixed 4 location-drift cases + added a stopgap parity test).

This single-sources the card off `providedBy`: the page now derives it from the canonical Office, so no inline copy exists for providedBy-backed Services and drift is structurally impossible.

Changes:
- `configHelper.ts`: extracted `getOfficeContactCard(office)` (the Office→card synthesis, reused by `getOfficeDetailBySlug`) and added `getServiceOfficeCard(service)` — derives the card from the providing Office (`getOfficeForService`), falling back to the Service's inline free-text `office`.
- `service-details/[slug].vue`: renders `officeInfo` from `getServiceOfficeCard(canonical)` instead of `service.office`; card guarded by `v-if`.
- `services.json`: dropped the inline `detail.office` block from the 7 providedBy-backed Services (`birth-certificate`, `marriage-certificate`, `death-certificate`, `vaccination`, `emergency-response`, `cswdo-services`, `property-declaration`). Each was verified to resolve to a real, visible Office whose fields fully cover the dropped block before stripping.
- `config.ts` + `services.schema.json`: `ServiceDetail.office` is now optional (dropped from the schema `required` list).

The 9 providerless BPLO/business Services (no `providedBy`) keep their inline free-text `office` and render via the fallback.

## AC coverage
- **Card renders from canonical Office via providedBy; no inline `detail.office` remains** — `getServiceOfficeCard` + page wiring; test `no providedBy-backed Service carries an inline detail.office (#212)` and `birth-certificate renders the civil-registry Office card via providedBy`.
- **Providerless Services still render an Office card via fallback** — test `falls back to the inline free-text office for a providerless Service` (`business-permit-new`).
- **No contact-data drift possible (card read from the Office entity)** — test `getServiceOfficeCard derives a providedBy Service's card straight from its Office (no drift possible)`: for every providedBy Service it asserts the card `toEqual(getOfficeContactCard(office))` and reflects live Office fields, never a stored copy. The #211 stopgap parity test was removed.
- **`pnpm validate`, lint, typecheck, tests pass** — see Quality gate.

## Quality gate
- `pnpm validate` — pass
- `pnpm lint` — pass
- `pnpm typecheck` — pass (exit 0)
- `pnpm test` — pass (7 files, 153 tests)
- `pnpm build` — pass (requires `NUXT_SITE_URL`; CI's gate does not run build)

Closes #212
