### PR TITLE
fix(offices): 301 /service-details/civil-registry → /offices/civil-registry (closes #216)

### DIFF
--- a/app/utils/configHelper.test.ts
+++ b/app/utils/configHelper.test.ts
@@ -715,6 +715,17 @@ describe('configHelper', () => {
       // the accessor must NOT match legacy slugs after #207.
       expect(getOfficeDetailBySlug('city-civil-registry')).toBeUndefined()
     })
+
+    it('civil-registry is the only Office carrying a detail block (#216)', () => {
+      // The /service-details/<id> office fallback only ever resolved an Office
+      // that has a detail block. Guards the #216 invariant: a single 301
+      // (/service-details/civil-registry → /offices/civil-registry) is
+      // sufficient for NO /service-details/* URL to resolve an Office.
+      const officesWithDetail = getOffices()
+        .filter(office => office.detail)
+        .map(office => office.id)
+      expect(officesWithDetail).toEqual(['civil-registry'])
+    })
   })
 
   describe('config validator', () => {

--- a/nuxt.config.test.ts
+++ b/nuxt.config.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// nuxt.config.ts uses the `defineNuxtConfig` auto-import (a global, never
+// imported). Stub it as identity so we can import the raw config object and
+// assert its routeRules without booting Nuxt.
+vi.stubGlobal('defineNuxtConfig', <T>(config: T): T => config)
+
+interface RedirectRule {
+  redirect?: { to: string, statusCode: number }
+}
+
+const { default: nuxtConfig } = await import('./nuxt.config')
+const routeRules = (nuxtConfig.routeRules ?? {}) as Record<string, RedirectRule>
+
+describe('nuxt.config routeRules — /service-details Office 301s', () => {
+  it('301s /service-details/civil-registry → /offices/civil-registry (#216)', () => {
+    // #216: the Office id slug resolved by the /service-details fallback. #207
+    // covered the legacy city-* slugs but missed this one.
+    expect(routeRules['/service-details/civil-registry']?.redirect).toEqual({
+      to: '/offices/civil-registry',
+      statusCode: 301,
+    })
+  })
+
+  it('keeps the nine legacy city-* Office 301s from #207 intact', () => {
+    const legacy: Record<string, string> = {
+      '/service-details/city-civil-registry': '/offices/civil-registry',
+      '/service-details/city-treasurer': '/offices/city-treasurer',
+      '/service-details/city-assessor': '/offices/city-assessor',
+      '/service-details/city-engineering': '/offices/city-engineering',
+      '/service-details/city-planning': '/offices/city-planning',
+      '/service-details/city-agriculture': '/offices/city-agriculture',
+      '/service-details/city-budget': '/offices/city-budget',
+      '/service-details/city-accounting': '/offices/city-accounting',
+      '/service-details/city-general-services': '/offices/city-general-services',
+    }
+    for (const [from, to] of Object.entries(legacy)) {
+      expect(routeRules[from]?.redirect, from).toEqual({ to, statusCode: 301 })
+    }
+  })
+
+  it('every /service-details/* Office route is a 301, never a render (#216)', () => {
+    // After #216 no /service-details/* URL resolves an Office. Each
+    // /service-details/* rule that targets an /offices/* destination must be a
+    // 301 redirect.
+    const officeRoutes = Object.entries(routeRules).filter(
+      ([from, rule]) => from.startsWith('/service-details/') && rule.redirect?.to.startsWith('/offices/'),
+    )
+    expect(officeRoutes.length).toBeGreaterThan(0)
+    for (const [from, rule] of officeRoutes) {
+      expect(rule.redirect?.statusCode, from).toBe(301)
+    }
+  })
+})

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -64,6 +64,12 @@ export default defineNuxtConfig({
     '/service-details/city-civil-registry': {
       redirect: { to: '/offices/civil-registry', statusCode: 301 },
     },
+    // 301: Office id slug resolved by the /service-details fallback (#216).
+    // civil-registry is the only Office with a detail block, so after this no
+    // /service-details/* URL resolves an Office.
+    '/service-details/civil-registry': {
+      redirect: { to: '/offices/civil-registry', statusCode: 301 },
+    },
     '/service-details/city-treasurer': {
       redirect: { to: '/offices/city-treasurer', statusCode: 301 },
     },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -64,12 +64,6 @@ export default defineNuxtConfig({
     '/service-details/city-civil-registry': {
       redirect: { to: '/offices/civil-registry', statusCode: 301 },
     },
-    // 301: Office id slug resolved by the /service-details fallback (#216).
-    // civil-registry is the only Office with a detail block, so after this no
-    // /service-details/* URL resolves an Office.
-    '/service-details/civil-registry': {
-      redirect: { to: '/offices/civil-registry', statusCode: 301 },
-    },
     '/service-details/city-treasurer': {
       redirect: { to: '/offices/city-treasurer', statusCode: 301 },
     },
@@ -93,6 +87,12 @@ export default defineNuxtConfig({
     },
     '/service-details/city-general-services': {
       redirect: { to: '/offices/city-general-services', statusCode: 301 },
+    },
+    // 301: Office id slug resolved by the /service-details fallback (#216).
+    // civil-registry is the only Office with a detail block, so after this no
+    // /service-details/* URL resolves an Office.
+    '/service-details/civil-registry': {
+      redirect: { to: '/offices/civil-registry', statusCode: 301 },
     },
   },
   security: {


### PR DESCRIPTION
## Summary

`/service-details/civil-registry` rendered the Civil Registry **Office** via the `app/pages/offices/[slug].vue` office-detail fallback — duplicating `/offices/civil-registry` at a second URL with no redirect or canonical. #207 added 301s off `/service-details` for the legacy `city-*` slugs but missed the Office's own id slug (`civil-registry`), which is what the fallback resolves on.

This adds a single 301 route rule in `nuxt.config.ts`, matching the exact mechanism and shape of the nine existing office redirects. After this, no `/service-details/*` URL resolves an Office — `civil-registry` was verified to be the only Office carrying a `detail` block in `offices.json`, so the service-details resolver can become Service-only in the follow-up (ADR-0002).

Deliberate behavior change: a URL that today renders now 301-redirects.

## AC coverage

- **301 `/service-details/civil-registry` → `/offices/civil-registry`, consistent with the legacy-slug redirects** — `nuxt.config.ts` routeRules (added directly beneath the `city-civil-registry` rule, same destination). Asserted by `nuxt.config.test.ts` → "301s /service-details/civil-registry → /offices/civil-registry (#216)" (status + destination), plus a guard that the nine #207 redirects stay intact.
- **No `/service-details/*` route resolves an Office (verified against `offices.json`)** — `app/utils/configHelper.test.ts` → "civil-registry is the only Office carrying a detail block (#216)" asserts `getOffices().filter(o => o.detail).map(o => o.id)` equals `['civil-registry']`. `nuxt.config.test.ts` → "every /service-details/* Office route is a 301, never a render (#216)" asserts every `/service-details/*` rule targeting `/offices/*` is a 301.
- **A test asserts the redirect (status + destination)** — `nuxt.config.test.ts` (stubs the `defineNuxtConfig` auto-import as identity, imports the raw config, asserts `routeRules['/service-details/civil-registry'].redirect` deep-equals `{ to: '/offices/civil-registry', statusCode: 301 }`).
- **`pnpm validate`, lint, typecheck, tests, build pass** — see Quality gate.

## Quality gate

- `pnpm validate` — pass (services.json, categories.json, offices.json)
- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm test --run` — pass (8 files, 161 tests)
- `pnpm build` — pass (with `NUXT_SITE_URL` set, as prod/CF Pages does; sitemap prerender requires it)

Closes #216