### PR TITLE
refactor(services): pageViews View resolver seam (closes #217)

### DIFF
--- a/app/pages/offices/[slug].vue
+++ b/app/pages/offices/[slug].vue
@@ -2,15 +2,14 @@
 usePageOgImage()
 
 const route = useRoute()
-const slug = route.params.slug as string
 
-// Canonical Office detail: resolved by Office id directly (own /offices/<id>
-// route namespace, #207). An Office is a place + contact + the Services it
-// provides — NOT a Service-shaped transaction page, so this renders a
-// directory-record layout (identity, contact, visit, services) rather than the
-// process/requirements/FAQ shape used by /service-details.
-const office = getOfficeBySlug(slug)
-if (!office) {
+// Page resolution lives behind the View resolver seam (ADR-0002): the facade
+// resolves the Office, its group name, the Services it provides and the maps
+// link; the page only renders and guards. An Office is a place + contact + the
+// Services it provides — NOT a Service-shaped transaction page, so this renders
+// a directory-record layout (identity, contact, visit, services).
+const view = officeView(route.params.slug as string)
+if (!view) {
   throw createError({
     statusCode: 404,
     statusMessage: 'Office not found',
@@ -18,29 +17,7 @@ if (!office) {
   })
 }
 
-const groupName = computed(() => getOfficeGroupBySlug(office.groupId)?.name ?? '')
-
-// Services this Office provides (via `providedBy`). Each links to its own
-// /service-details page ONLY when that Service has a `detail` block; catalog-
-// only Services have no page and render as a plain, non-clickable card.
-// `office.additionalServices` are office-only offerings that are not Service
-// records yet (no page, absent from search): appended as plain cards, deduped
-// by name so a graduated service never appears twice.
-const services = computed(() => {
-  const provided = getAllServices()
-    .filter(s => s.providedBy === office.id && !s.hidden)
-    .map(s => ({ name: s.title, link: s.detail ? `/service-details/${s.id}` : undefined }))
-  const providedNames = new Set(provided.map(s => s.name))
-  const extra = (office.additionalServices ?? [])
-    .filter(name => !providedNames.has(name))
-    .map(name => ({ name, link: undefined as string | undefined }))
-  return [...provided, ...extra]
-})
-
-// No geo data on the Office schema — link to Google Maps by address.
-const mapsUrl = computed(
-  () => `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(office.location ?? office.name)}`,
-)
+const { office, groupName, services, mapsUrl } = view
 </script>
 
 <template>

--- a/app/pages/service-details/[slug].vue
+++ b/app/pages/service-details/[slug].vue
@@ -2,19 +2,13 @@
 usePageOgImage()
 
 const route = useRoute()
-const slug = route.params.slug as string
 
-// Canonical read path: a Service in services.json (or a first-class Office in
-// offices.json, #201) may carry an optional `detail` block. We merge in the
-// `title` so the existing template renders unchanged. Resolution order:
-// canonical Service detail → canonical Office detail. There is no other source.
-const canonical = getServiceBySlug(slug)
-
-const service = canonical?.detail
-  ? { ...canonical.detail, title: canonical.title }
-  : getOfficeDetailBySlug(slug)
-
-if (!service) {
+// Page resolution lives behind the View resolver seam (ADR-0002): the facade
+// resolves the canonical Service detail and shapes the Office card; the page
+// only renders and guards. Service-detail only — the legacy office URL is
+// handled by a 301 (#207/#216), so there is no office fallback here.
+const view = serviceDetailView(route.params.slug as string)
+if (!view) {
   throw createError({
     statusCode: 404,
     statusMessage: 'Service not found',
@@ -22,16 +16,7 @@ if (!service) {
   })
 }
 
-// Single-source the "Office Information" card off the providing Office via
-// `providedBy` (mirrors getOfficeForService) so it can never drift from the
-// canonical Office. getServiceOfficeCard falls back to the Service's inline
-// free-text `detail.office` for providers not yet first-class Offices (e.g.
-// BPLO business services). The office-detail path (getOfficeDetailBySlug)
-// already synthesises its own `office`, so reuse it directly. officeInfo may be
-// undefined when neither source resolves — the card is `v-if`-guarded.
-const officeInfo = canonical?.detail
-  ? getServiceOfficeCard(canonical)
-  : service.office
+const { service, officeInfo } = view
 
 const openFaq = ref<number | null>(null)
 

--- a/app/pages/services/[category].vue
+++ b/app/pages/services/[category].vue
@@ -2,17 +2,11 @@
 usePageOgImage()
 
 const route = useRoute()
-const categorySlug = route.params.category as string
 
-// Service Categories are sourced canonically (categories.json + services.json)
-// through the configHelper accessors — there is no other source. The
-// `isCanonicalCategory` gate keeps non-resident Categories (`government`,
-// `online`, which migrate in their own slices) off this route.
-const category = isCanonicalCategory(categorySlug)
-  ? getCategoryBySlug(categorySlug)
-  : undefined
-
-if (!category) {
+// Page resolution lives behind the View resolver seam (ADR-0002): the facade
+// does the configHelper lookups and shaping; the page only renders and guards.
+const view = categoryView(route.params.category as string)
+if (!view) {
   throw createError({
     statusCode: 404,
     statusMessage: 'Category not found',
@@ -20,30 +14,7 @@ if (!category) {
   })
 }
 
-// A catalog-only Service points back at its own category page (e.g.
-// /services/certificates). Treat that as "no dedicated page" so the card stays
-// non-interactive, matching the original behavior. Only a real destination
-// (e.g. /service-details/<id>) makes the card a link.
-const categoryHref = `/services/${categorySlug}`
-const services = getServicesByCategory(categorySlug).map(service => ({
-  id: service.id,
-  icon: service.icon,
-  title: service.title,
-  description: service.description,
-  fee: service.fee,
-  time: service.processingTime,
-  link: service.url && service.url !== categoryHref ? service.url : undefined,
-}))
-
-// Responsible Offices are first-class entities (#185) resolved from the
-// Category's Services via `providedBy` — Office <-> Category is many-to-many
-// through the Services.
-const offices = getOfficesForCategory(categorySlug).map(office => ({
-  title: office.name,
-  icon: office.icon,
-  description: office.description,
-  link: office.link,
-}))
+const { category, services, offices } = view
 </script>
 
 <template>

--- a/app/types/config.ts
+++ b/app/types/config.ts
@@ -369,7 +369,8 @@ export interface Faq {
  * Only present (as free text) for Services whose provider is NOT yet a
  * first-class Office (e.g. BPLO business services with no `providedBy`).
  * providedBy-backed Services derive the card from their canonical Office via
- * `getServiceOfficeCard`, so they carry no inline copy (#212, single source).
+ * `officeContactCard` (pageViews.ts), so they carry no inline copy (#212,
+ * single source).
  */
 export interface ServiceDetailOffice {
   name: string
@@ -407,8 +408,8 @@ export interface ServiceDetail {
 /**
  * Rich detail-page content for a first-class Office (#201). Reuses the canonical
  * Service `detail` shape but OMITS its `office` contact sub-block: an Office is
- * its own contact source, so `getOfficeDetailBySlug` synthesises the contact
- * card from the Office's own top-level fields rather than re-storing it here
+ * its own contact source, so its page (`officeView`, pageViews.ts) reads contact
+ * data from the Office's own top-level fields rather than re-storing it here
  * (single source of truth, no drift).
  */
 export type OfficeDetail = Omit<ServiceDetail, 'office'>

--- a/app/utils/configHelper.test.ts
+++ b/app/utils/configHelper.test.ts
@@ -6,8 +6,6 @@ import {
   getCategorySeoDescription,
   getMergedSiteConfig,
   getOfficeBySlug,
-  getOfficeContactCard,
-  getOfficeDetailBySlug,
   getOfficeForService,
   getOfficeGroupBySlug,
   getOfficeGroups,
@@ -18,7 +16,6 @@ import {
   getOgImageRouteConfig,
   getServiceBySlug,
   getServiceCategories,
-  getServiceOfficeCard,
   getServicesByCategory,
   getServiceSeoDescription,
   getSiteConfig,
@@ -585,111 +582,6 @@ describe('configHelper', () => {
     })
   })
 
-  describe('service-details Office card derivation (#212)', () => {
-    it('getOfficeContactCard synthesises the card from the Office\'s own fields', () => {
-      const office = getOfficeBySlug('civil-registry')!
-      const card = getOfficeContactCard(office)
-      expect(card).toEqual({
-        name: office.name,
-        location: office.location ?? '',
-        phone: office.phone,
-        mobile: office.mobile,
-        email: office.email,
-        facebook: office.facebook,
-        hours: office.hours ?? '',
-      })
-    })
-
-    it('getServiceOfficeCard derives a providedBy Service\'s card straight from its Office (no drift possible)', () => {
-      // The card is read from the canonical Office entity, NOT from any inline
-      // copy on the Service. By construction it cannot diverge from the Office
-      // page, which renders the same getOfficeContactCard output.
-      for (const service of getAllServices()) {
-        const office = getOfficeForService(service)
-        if (!office)
-          continue
-        const card = getServiceOfficeCard(service)
-        expect(card, service.id).toEqual(getOfficeContactCard(office))
-        // And it reflects the live Office fields, not a stored value.
-        expect(card!.name, service.id).toBe(office.name)
-        expect(card!.location, service.id).toBe(office.location ?? '')
-        expect(card!.hours, service.id).toBe(office.hours ?? '')
-      }
-    })
-
-    it('birth-certificate renders the civil-registry Office card via providedBy', () => {
-      const birth = getServiceBySlug('birth-certificate')!
-      expect(birth.detail?.office).toBeUndefined()
-      const office = getOfficeBySlug('civil-registry')!
-      expect(getServiceOfficeCard(birth)).toEqual(getOfficeContactCard(office))
-    })
-
-    it('falls back to the inline free-text office for a providerless Service', () => {
-      // BPLO business services have no first-class Office yet: the card comes
-      // from the Service's inline detail.office.
-      const biz = getServiceBySlug('business-permit-new')!
-      expect(biz.providedBy).toBeUndefined()
-      expect(getOfficeForService(biz)).toBeUndefined()
-      const card = getServiceOfficeCard(biz)
-      expect(card).toBeDefined()
-      expect(card).toEqual(biz.detail?.office)
-    })
-
-    it('returns undefined when a Service has neither a providing Office nor an inline office', () => {
-      expect(getServiceOfficeCard({ providedBy: undefined } as never)).toBeUndefined()
-    })
-  })
-
-  describe('getOfficeDetailBySlug (#207)', () => {
-    it('resolves civil-registry Office by canonical id', () => {
-      // #207: Office has its own /offices/<id> namespace; resolved by id only.
-      // The slug alias (city-civil-registry) introduced in #201 is removed.
-      const detail = getOfficeDetailBySlug('civil-registry')
-      expect(detail).toBeDefined()
-      expect(detail!.fullTitle).toBe('City Civil Registry Office')
-      expect(detail!.category).toBe('Certificates')
-      expect(detail!.processSteps.length).toBeGreaterThan(0)
-      expect(detail!.relatedServices.map(r => r.link)).toContain(
-        '/service-details/birth-certificate',
-      )
-    })
-
-    it('merges the Office name as `title` for the existing detail template', () => {
-      // Mirrors the canonical Service read path: { ...detail, title }.
-      const detail = getOfficeDetailBySlug('civil-registry')
-      expect(detail!.title).toBe('City Civil Registry')
-    })
-
-    it('synthesises the office contact card from the Office\'s own fields', () => {
-      // The `detail` block does NOT re-store contact info; the accessor derives
-      // the template's `office` card from the Office entity (single source of
-      // truth). Mutating offices.json contact would flow through here.
-      const office = getOfficeBySlug('civil-registry')!
-      const detail = getOfficeDetailBySlug('civil-registry')!
-      expect(detail.office).toEqual({
-        name: office.name,
-        location: office.location ?? '',
-        phone: office.phone,
-        mobile: office.mobile,
-        email: office.email,
-        facebook: office.facebook,
-        hours: office.hours ?? '',
-      })
-    })
-
-    it('returns undefined for the removed slug alias city-civil-registry', () => {
-      // Slug alias dropped in #207; 301 in nuxt.config handles SEO continuity.
-      expect(getOfficeDetailBySlug('city-civil-registry')).toBeUndefined()
-    })
-
-    it('returns undefined for unknown or hidden Offices', () => {
-      expect(getOfficeDetailBySlug('not-a-real-office')).toBeUndefined()
-      // Hidden Offices are excluded via getOffices, so their detail never leaks.
-      expect(getOfficeDetailBySlug('human-resource-management')).toBeUndefined()
-      expect(getOfficeDetailBySlug('barangay-hall')).toBeUndefined()
-    })
-  })
-
   describe('office route namespace (#207)', () => {
     it('civil-registry Office link points at /offices/civil-registry', () => {
       const civil = getOfficeBySlug('civil-registry')
@@ -703,17 +595,17 @@ describe('configHelper', () => {
       expect('slug' in civil!).toBe(false)
     })
 
-    it('getOfficeDetailBySlug resolves by id on the /offices/<id> route', () => {
+    it('getOfficeBySlug resolves by id on the /offices/<id> route', () => {
       // The /offices/[slug].vue page passes route.params.slug (= office.id).
-      const detail = getOfficeDetailBySlug('civil-registry')
-      expect(detail).toBeDefined()
-      expect(detail!.title).toBe('City Civil Registry')
+      const office = getOfficeBySlug('civil-registry')
+      expect(office).toBeDefined()
+      expect(office!.name).toBe('City Civil Registry')
     })
 
-    it('legacy slug city-civil-registry no longer resolves via getOfficeDetailBySlug', () => {
+    it('legacy slug city-civil-registry no longer resolves to an Office', () => {
       // 301 redirect in nuxt.config handles the URL continuity;
       // the accessor must NOT match legacy slugs after #207.
-      expect(getOfficeDetailBySlug('city-civil-registry')).toBeUndefined()
+      expect(getOfficeBySlug('city-civil-registry')).toBeUndefined()
     })
 
     it('civil-registry is the only Office carrying a detail block (#216)', () => {
@@ -972,24 +864,15 @@ describe('configHelper', () => {
       }
     })
 
-    it('every /service-details slug resolves from one of the two canonical sources only', () => {
-      // The page resolves: canonical Service detail -> canonical Office detail.
-      // No third (TS-module) source exists anymore.
+    it('every /service-details slug resolves from the canonical Service source only', () => {
+      // After ADR-0002 the page resolves Service detail only — the office
+      // fallback is dropped (the legacy office URL is redirected by a 301).
       const detailSlugs = getAllServices()
         .filter(s => s.detail)
         .map(s => s.id)
       for (const slug of detailSlugs) {
-        const fromService = getServiceBySlug(slug)?.detail
-        const fromOffice = getOfficeDetailBySlug(slug)
-        expect(Boolean(fromService) || Boolean(fromOffice), slug).toBe(true)
+        expect(Boolean(getServiceBySlug(slug)?.detail), slug).toBe(true)
       }
-    })
-
-    it('a first-class Office detail still resolves via getOfficeDetailBySlug', () => {
-      const detail = getOfficeDetailBySlug('civil-registry')
-      expect(detail).toBeDefined()
-      expect(detail!.title).toBeTruthy()
-      expect(detail!.office).toBeDefined()
     })
   })
 })

--- a/app/utils/configHelper.ts
+++ b/app/utils/configHelper.ts
@@ -433,13 +433,12 @@ export function getOfficeBySlug(slug: string): Office | undefined {
   return getOffices().find(office => office.id === slug)
 }
 
-/**
- * Office-card synthesis and the /service-details Office card moved to the View
- * resolver seam (`app/utils/pageViews.ts`, ADR-0002): `officeContactCard` and
- * `toServiceDetailView`. The office-detail fallback for /service-details
- * (`getOfficeDetailBySlug`) is dropped — the legacy office URL is redirected by
- * a 301 (#207/#216), so /offices/<id> is resolved by `officeView` instead.
- */
+// Office-card synthesis (`getServiceOfficeCard`) and the /service-details Office
+// card moved to the View resolver seam (`app/utils/pageViews.ts`, ADR-0002):
+// `officeContactCard` and `toServiceDetailView`. The office-detail fallback for
+// /service-details (`getOfficeDetailBySlug`) is dropped — the legacy office URL
+// is redirected by a 301 (#207/#216), so /offices/<id> is resolved by
+// `officeView` instead.
 
 /**
  * Get every visible Office Group (hidden Groups excluded).

--- a/app/utils/configHelper.ts
+++ b/app/utils/configHelper.ts
@@ -18,8 +18,6 @@ import type {
   OfficialsConfig,
   OgImageRouteConfig,
   SeoRouteConfig,
-  ServiceDetail,
-  ServiceDetailOffice,
   ServiceItem,
   ServicesConfig,
   SiteConfig,
@@ -436,64 +434,12 @@ export function getOfficeBySlug(slug: string): Office | undefined {
 }
 
 /**
- * Resolve an Office's rich detail-page content for the `/offices/<slug>` route
- * (#207), merged with the Office `name` as `title` so the detail template
- * renders unchanged (mirrors the canonical Service read path). Matches on the
- * Office `id` directly — the `slug` alias introduced in #201 for the legacy
- * `/service-details/city-civil-registry` URL is no longer needed now that
- * Offices have their own `/offices/<id>` namespace with a 301 from the legacy
- * URL. Returns undefined for unknown/hidden Offices or Offices without a
- * `detail` block. Hidden Offices are excluded via `getOffices`.
+ * Office-card synthesis and the /service-details Office card moved to the View
+ * resolver seam (`app/utils/pageViews.ts`, ADR-0002): `officeContactCard` and
+ * `toServiceDetailView`. The office-detail fallback for /service-details
+ * (`getOfficeDetailBySlug`) is dropped — the legacy office URL is redirected by
+ * a 301 (#207/#216), so /offices/<id> is resolved by `officeView` instead.
  */
-export function getOfficeDetailBySlug(
-  slug: string,
-): (ServiceDetail & { title: string }) | undefined {
-  const office = getOffices().find(o => o.id === slug)
-  if (!office?.detail)
-    return undefined
-  // The Office is its own contact source: synthesise the detail-template's
-  // `office` card from the Office's top-level fields rather than re-storing it
-  // in the `detail` block (single source of truth).
-  return {
-    ...office.detail,
-    title: office.name,
-    office: getOfficeContactCard(office),
-  }
-}
-
-/**
- * Synthesise the detail-page "Office Information" card from a first-class
- * Office's own top-level fields. The Office entity is the single source of
- * truth for contact data — this never reads an inline `detail.office` copy, so
- * no drift between a Service/Office page and its canonical Office is possible.
- */
-export function getOfficeContactCard(office: Office): ServiceDetailOffice {
-  return {
-    name: office.name,
-    location: office.location ?? '',
-    phone: office.phone,
-    mobile: office.mobile,
-    email: office.email,
-    facebook: office.facebook,
-    hours: office.hours ?? '',
-  }
-}
-
-/**
- * Resolve the "Office Information" card for a /service-details/<slug> page.
- * Single-sources off the providing Office when the Service has `providedBy`
- * (mirrors getOfficeForService); otherwise falls back to the Service's inline
- * free-text `detail.office` for providers not yet first-class Offices (e.g.
- * BPLO business services). Returns undefined when neither resolves.
- */
-export function getServiceOfficeCard(
-  service: ServiceItem,
-): ServiceDetailOffice | undefined {
-  const office = getOfficeForService(service)
-  if (office)
-    return getOfficeContactCard(office)
-  return service.detail?.office
-}
 
 /**
  * Get every visible Office Group (hidden Groups excluded).

--- a/app/utils/pageViews.test.ts
+++ b/app/utils/pageViews.test.ts
@@ -185,6 +185,25 @@ describe('toOfficeView', () => {
     expect(named).toHaveLength(1)
   })
 
+  it('prefers the detail-bearing duplicate regardless of order', () => {
+    const detailFirst = toOfficeView({
+      office: makeOffice({ id: 'civil-registry' }),
+      services: [
+        makeService({ id: 'a', title: 'Birth Certificate', providedBy: 'civil-registry', detail: makeDetail() }),
+        makeService({ id: 'b', title: 'Birth Certificate', providedBy: 'civil-registry', detail: undefined }),
+      ],
+    })
+    const detailLast = toOfficeView({
+      office: makeOffice({ id: 'civil-registry' }),
+      services: [
+        makeService({ id: 'b', title: 'Birth Certificate', providedBy: 'civil-registry', detail: undefined }),
+        makeService({ id: 'a', title: 'Birth Certificate', providedBy: 'civil-registry', detail: makeDetail() }),
+      ],
+    })
+    expect(detailFirst.services[0]!.link).toBe('/service-details/a')
+    expect(detailLast.services[0]!.link).toBe('/service-details/a')
+  })
+
   it('gives a catalog-only provided Service no link', () => {
     const view = toOfficeView({
       office: makeOffice({ id: 'civil-registry' }),

--- a/app/utils/pageViews.test.ts
+++ b/app/utils/pageViews.test.ts
@@ -1,0 +1,272 @@
+import type {
+  Category,
+  Office,
+  OfficeGroup,
+  ServiceDetail,
+  ServiceItem,
+} from '@/types/config'
+import { describe, expect, it } from 'vitest'
+import { getOfficeBySlug, getServiceBySlug } from './configHelper'
+import {
+  categoryView,
+  officeContactCard,
+  officeView,
+  serviceDetailView,
+  toCategoryView,
+  toOfficeView,
+  toServiceDetailView,
+} from './pageViews'
+
+// ---------------------------------------------------------------------------
+// Fixture builders — keep the shaper tests IO-free. The shapers take canonical
+// records, so we hand-build minimal records rather than reading config.
+// ---------------------------------------------------------------------------
+
+function makeCategory(over: Partial<Category> = {}): Category {
+  return {
+    id: 'certificates',
+    name: 'Certificates',
+    icon: 'bi-file',
+    badgeText: 'Documents',
+    description: 'Vital records',
+    ...over,
+  }
+}
+
+function makeService(over: Partial<ServiceItem> = {}): ServiceItem {
+  return {
+    id: 'birth-certificate',
+    title: 'Birth Certificate',
+    description: 'Get a birth certificate',
+    category: 'Certificates',
+    categoryId: 'certificates',
+    keywords: [],
+    url: '/service-details/birth-certificate',
+    ...over,
+  }
+}
+
+function makeDetail(over: Partial<ServiceDetail> = {}): ServiceDetail {
+  return {
+    fullTitle: 'Birth Certificate Request',
+    category: 'Certificates',
+    categoryLink: '/services/certificates',
+    badgeText: 'Certificate',
+    badgeIcon: 'bi-file',
+    description: 'Request a birth certificate',
+    quickStats: [],
+    processSteps: [],
+    requirements: [],
+    faqs: [],
+    relatedServices: [],
+    ...over,
+  }
+}
+
+function makeOffice(over: Partial<Office> = {}): Office {
+  return {
+    id: 'civil-registry',
+    name: 'City Civil Registry',
+    groupId: 'frontline-services',
+    icon: 'bi-building',
+    description: 'Vital records office',
+    link: '/offices/civil-registry',
+    location: 'City Hall',
+    phone: '123',
+    hours: '8-5',
+    ...over,
+  }
+}
+
+function makeGroup(over: Partial<OfficeGroup> = {}): OfficeGroup {
+  return {
+    id: 'frontline-services',
+    name: 'Frontline Services',
+    description: 'Public-facing offices',
+    ...over,
+  }
+}
+
+describe('toCategoryView', () => {
+  it('maps a Service with a real destination to a linked card', () => {
+    const view = toCategoryView({
+      category: makeCategory(),
+      services: [makeService({ url: '/service-details/birth-certificate' })],
+      offices: [],
+    })
+    expect(view.services[0]!.link).toBe('/service-details/birth-certificate')
+  })
+
+  it('suppresses the link for a catalog-only Service that points back at its category page', () => {
+    // A catalog-only Service's url is its own category page — not a dedicated
+    // destination — so the card must render non-interactive (no link).
+    const view = toCategoryView({
+      category: makeCategory({ id: 'certificates' }),
+      services: [makeService({ url: '/services/certificates' })],
+      offices: [],
+    })
+    expect(view.services[0]!.link).toBeUndefined()
+  })
+
+  it('maps the Category record and Office cards through', () => {
+    const category = makeCategory()
+    const view = toCategoryView({
+      category,
+      services: [makeService({ icon: 'bi-x', fee: '₱100', processingTime: '1 day' })],
+      offices: [makeOffice()],
+    })
+    expect(view.category).toBe(category)
+    expect(view.services[0]).toMatchObject({
+      id: 'birth-certificate',
+      icon: 'bi-x',
+      title: 'Birth Certificate',
+      fee: '₱100',
+      time: '1 day',
+    })
+    expect(view.offices[0]).toEqual({
+      title: 'City Civil Registry',
+      icon: 'bi-building',
+      description: 'Vital records office',
+      link: '/offices/civil-registry',
+    })
+  })
+})
+
+describe('toServiceDetailView', () => {
+  it('resolves the Office card from the providing Office (providedBy)', () => {
+    const office = makeOffice()
+    const view = toServiceDetailView({
+      service: { ...makeService({ providedBy: 'civil-registry' }), detail: makeDetail() },
+      office,
+    })
+    expect(view.officeInfo).toEqual(officeContactCard(office))
+    expect(view.officeInfo!.name).toBe(office.name)
+  })
+
+  it('merges the Service title into the detail for the template', () => {
+    const view = toServiceDetailView({
+      service: { ...makeService({ title: 'Birth Certificate' }), detail: makeDetail({ fullTitle: 'BC' }) },
+    })
+    expect(view.service.title).toBe('Birth Certificate')
+    expect(view.service.fullTitle).toBe('BC')
+  })
+
+  it('falls back to the inline detail.office when no providing Office is supplied', () => {
+    const inline = {
+      name: 'BPLO',
+      location: 'Annex',
+      hours: '8-5',
+    }
+    const view = toServiceDetailView({
+      service: { ...makeService({ providedBy: undefined }), detail: makeDetail({ office: inline }) },
+    })
+    expect(view.officeInfo).toEqual(inline)
+  })
+
+  it('leaves officeInfo undefined when neither an Office nor an inline card exists', () => {
+    const view = toServiceDetailView({
+      service: { ...makeService(), detail: makeDetail() },
+    })
+    expect(view.officeInfo).toBeUndefined()
+  })
+})
+
+describe('toOfficeView', () => {
+  it('dedupes two provided Services with the same title to one', () => {
+    const view = toOfficeView({
+      office: makeOffice({ id: 'civil-registry' }),
+      group: makeGroup(),
+      services: [
+        makeService({ id: 'a', title: 'Birth Certificate', providedBy: 'civil-registry', detail: makeDetail() }),
+        makeService({ id: 'b', title: 'Birth Certificate', providedBy: 'civil-registry', detail: makeDetail() }),
+      ],
+    })
+    const named = view.services.filter(s => s.name === 'Birth Certificate')
+    expect(named).toHaveLength(1)
+  })
+
+  it('gives a catalog-only provided Service no link', () => {
+    const view = toOfficeView({
+      office: makeOffice({ id: 'civil-registry' }),
+      services: [makeService({ id: 'a', title: 'Walk-in record', providedBy: 'civil-registry', detail: undefined })],
+    })
+    expect(view.services[0]).toEqual({ name: 'Walk-in record', link: undefined })
+  })
+
+  it('links a detail-bearing provided Service to its /service-details page', () => {
+    const view = toOfficeView({
+      office: makeOffice({ id: 'civil-registry' }),
+      services: [makeService({ id: 'birth-certificate', providedBy: 'civil-registry', detail: makeDetail() })],
+    })
+    expect(view.services[0]!.link).toBe('/service-details/birth-certificate')
+  })
+
+  it('excludes Services provided by other Offices and hidden Services', () => {
+    const view = toOfficeView({
+      office: makeOffice({ id: 'civil-registry' }),
+      services: [
+        makeService({ id: 'a', title: 'Mine', providedBy: 'civil-registry', detail: makeDetail() }),
+        makeService({ id: 'b', title: 'Other office', providedBy: 'treasurer', detail: makeDetail() }),
+        makeService({ id: 'c', title: 'Hidden', providedBy: 'civil-registry', hidden: true, detail: makeDetail() }),
+      ],
+    })
+    const names = view.services.map(s => s.name)
+    expect(names).toEqual(['Mine'])
+  })
+
+  it('appends additionalServices as plain cards, deduped against provided Services', () => {
+    const view = toOfficeView({
+      office: makeOffice({
+        id: 'civil-registry',
+        additionalServices: ['Birth Certificate', 'Notarization'],
+      }),
+      services: [makeService({ id: 'a', title: 'Birth Certificate', providedBy: 'civil-registry', detail: makeDetail() })],
+    })
+    const names = view.services.map(s => s.name)
+    expect(names).toEqual(['Birth Certificate', 'Notarization'])
+    expect(view.services.find(s => s.name === 'Notarization')!.link).toBeUndefined()
+  })
+
+  it('derives the group name and a maps URL from the Office address', () => {
+    const view = toOfficeView({
+      office: makeOffice({ location: 'City Hall, Las Piñas' }),
+      group: makeGroup({ name: 'Frontline Services' }),
+      services: [],
+    })
+    expect(view.groupName).toBe('Frontline Services')
+    expect(view.mapsUrl).toContain(encodeURIComponent('City Hall, Las Piñas'))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Facade smoke tests against the real config — the facade owns the IO; these
+// pin that a missed lookup returns undefined (so the page throws 404) and that
+// resolution is behavior-equivalent to the pre-seam pages.
+// ---------------------------------------------------------------------------
+
+describe('facades (real config)', () => {
+  it('categoryView resolves a live Category and gates a non-resident one', () => {
+    expect(categoryView('certificates')).toBeDefined()
+    expect(categoryView('government')).toBeUndefined()
+    expect(categoryView('not-a-real-category')).toBeUndefined()
+  })
+
+  it('serviceDetailView resolves a detail-bearing Service and its providedBy Office card', () => {
+    const view = serviceDetailView('birth-certificate')
+    expect(view).toBeDefined()
+    const office = getOfficeBySlug('civil-registry')!
+    expect(view!.officeInfo).toEqual(officeContactCard(office))
+    expect(view!.service.title).toBe(getServiceBySlug('birth-certificate')!.title)
+  })
+
+  it('serviceDetailView returns undefined for unknown slugs (Service-detail only, no office fallback)', () => {
+    expect(serviceDetailView('not-a-real-service')).toBeUndefined()
+    // The legacy office URL is a 301 now — it must not resolve a View here.
+    expect(serviceDetailView('civil-registry')).toBeUndefined()
+  })
+
+  it('officeView resolves a live Office and returns undefined for unknown/hidden', () => {
+    expect(officeView('civil-registry')).toBeDefined()
+    expect(officeView('not-a-real-office')).toBeUndefined()
+  })
+})

--- a/app/utils/pageViews.ts
+++ b/app/utils/pageViews.ts
@@ -150,7 +150,7 @@ export function officeContactCard(office: Office): ServiceDetailOffice {
 }
 
 /**
- * Pure shaper for the /service-details/<slug> page. Resolves Service detail
+ * Pure shaper for the /service-details/<slug> page. Shapes Service detail
  * only (the office fallback is dropped — the legacy office URL is redirected by
  * the blocker, #207/#216).
  *
@@ -212,30 +212,36 @@ export interface OfficeRecords {
  * Services render as a plain, non-clickable card. `office.additionalServices`
  * are office-only offerings (not Service records yet, no page) appended as plain
  * cards. The whole list is deduped by name, so a graduated service never appears
- * twice and two provided Services with the same title collapse to one.
+ * twice and two provided Services with the same title collapse to one —
+ * order-independently preferring the one with a `detail` page so a detail-less
+ * duplicate never suppresses a real link.
  */
 export function toOfficeView(records: OfficeRecords): OfficeView {
   const { office, group, services } = records
-  const seen = new Set<string>()
+  const seen = new Map<string, OfficeServiceCard>()
   const cards: OfficeServiceCard[] = []
 
   for (const service of services) {
     if (service.providedBy !== office.id || service.hidden)
       continue
-    if (seen.has(service.title))
+    const link = service.detail ? `/service-details/${service.id}` : undefined
+    const existing = seen.get(service.title)
+    if (existing) {
+      if (!existing.link && link)
+        existing.link = link
       continue
-    seen.add(service.title)
-    cards.push({
-      name: service.title,
-      link: service.detail ? `/service-details/${service.id}` : undefined,
-    })
+    }
+    const card: OfficeServiceCard = { name: service.title, link }
+    seen.set(service.title, card)
+    cards.push(card)
   }
 
   for (const name of office.additionalServices ?? []) {
     if (seen.has(name))
       continue
-    seen.add(name)
-    cards.push({ name, link: undefined })
+    const card: OfficeServiceCard = { name, link: undefined }
+    seen.set(name, card)
+    cards.push(card)
   }
 
   return {

--- a/app/utils/pageViews.ts
+++ b/app/utils/pageViews.ts
@@ -1,0 +1,264 @@
+import type {
+  Category,
+  Office,
+  OfficeGroup,
+  ServiceDetail,
+  ServiceDetailOffice,
+  ServiceItem,
+} from '@/types/config'
+
+import {
+  getAllServices,
+  getCategoryBySlug,
+  getOfficeBySlug,
+  getOfficeForService,
+  getOfficeGroupBySlug,
+  getOfficesForCategory,
+  getServiceBySlug,
+  getServicesByCategory,
+  isCanonicalCategory,
+} from '@/utils/configHelper'
+
+// ---------------------------------------------------------------------------
+// View resolver seam (ADR-0002).
+//
+// A View is a render-ready projection of canonical Service / Office / Category
+// records, shaped for exactly one route's template. Each route gets a *bound
+// facade* (`categoryView`, `serviceDetailView`, `officeView`) that does the
+// `configHelper` lookups and delegates to a *pure shaper* (`toCategoryView`,
+// `toServiceDetailView`, `toOfficeView`) that holds all mapping/dedupe/merge.
+//
+// The shapers are framework- and IO-free: they take canonical records and
+// return a View, so they are unit-testable without rendering a page. The
+// facades own the IO (reading through configHelper); a page calls one facade
+// and keeps only a `if (!view) throw createError(404)` guard.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Category View — /services/<category>
+// ---------------------------------------------------------------------------
+
+export interface CategoryServiceCard {
+  id: string
+  icon?: string
+  title: string
+  description: string
+  fee?: string
+  time?: string
+  link?: string
+}
+
+export interface CategoryOfficeCard {
+  title: string
+  icon: string
+  description: string
+  link: string
+}
+
+export interface CategoryView {
+  category: Category
+  services: CategoryServiceCard[]
+  offices: CategoryOfficeCard[]
+}
+
+export interface CategoryRecords {
+  category: Category
+  services: ServiceItem[]
+  offices: Office[]
+}
+
+/**
+ * Pure shaper for the /services/<category> page.
+ *
+ * A catalog-only Service points back at its own category page (e.g. its `url`
+ * is `/services/certificates`). Treat that as "no dedicated page" so the card
+ * stays non-interactive; only a real destination (e.g. `/service-details/<id>`)
+ * makes the card a link.
+ */
+export function toCategoryView(records: CategoryRecords): CategoryView {
+  const categoryHref = `/services/${records.category.id}`
+  return {
+    category: records.category,
+    services: records.services.map(service => ({
+      id: service.id,
+      icon: service.icon,
+      title: service.title,
+      description: service.description,
+      fee: service.fee,
+      time: service.processingTime,
+      link: service.url && service.url !== categoryHref ? service.url : undefined,
+    })),
+    offices: records.offices.map(office => ({
+      title: office.name,
+      icon: office.icon,
+      description: office.description,
+      link: office.link,
+    })),
+  }
+}
+
+/**
+ * Bound facade: resolve a category slug into its CategoryView. The
+ * `isCanonicalCategory` gate keeps non-resident Categories (`government`,
+ * `online`) off this route. Returns undefined on a missed lookup so the page
+ * can throw a 404.
+ */
+export function categoryView(slug: string): CategoryView | undefined {
+  const category = isCanonicalCategory(slug)
+    ? getCategoryBySlug(slug)
+    : undefined
+  if (!category)
+    return undefined
+  return toCategoryView({
+    category,
+    services: getServicesByCategory(slug),
+    offices: getOfficesForCategory(slug),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Service Detail View — /service-details/<slug>
+// ---------------------------------------------------------------------------
+
+export interface ServiceDetailView {
+  service: ServiceDetail & { title: string }
+  officeInfo?: ServiceDetailOffice
+}
+
+export interface ServiceDetailRecords {
+  service: ServiceItem & { detail: ServiceDetail }
+  office?: Office
+}
+
+/**
+ * Synthesise the detail-page "Office Information" card from a first-class
+ * Office's own top-level fields. The Office entity is the single source of
+ * truth for contact data — this never reads an inline `detail.office` copy, so
+ * no drift between a Service page and its canonical Office is possible.
+ * (Migrated from configHelper's office-card synthesis per ADR-0002.)
+ */
+export function officeContactCard(office: Office): ServiceDetailOffice {
+  return {
+    name: office.name,
+    location: office.location ?? '',
+    phone: office.phone,
+    mobile: office.mobile,
+    email: office.email,
+    facebook: office.facebook,
+    hours: office.hours ?? '',
+  }
+}
+
+/**
+ * Pure shaper for the /service-details/<slug> page. Resolves Service detail
+ * only (the office fallback is dropped — the legacy office URL is redirected by
+ * the blocker, #207/#216).
+ *
+ * The "Office Information" card single-sources off the providing Office when one
+ * is supplied (via `providedBy`), so it can never drift from the canonical
+ * Office. It falls back to the Service's inline free-text `detail.office` for
+ * providers not yet first-class Offices (e.g. BPLO business services).
+ */
+export function toServiceDetailView(records: ServiceDetailRecords): ServiceDetailView {
+  const { service, office } = records
+  return {
+    service: { ...service.detail, title: service.title },
+    officeInfo: office ? officeContactCard(office) : service.detail.office,
+  }
+}
+
+/**
+ * Bound facade: resolve a Service slug into its ServiceDetailView. Resolves a
+ * canonical Service detail only; a Service without a `detail` block (catalog-
+ * only) or an unknown slug returns undefined so the page can throw a 404.
+ */
+export function serviceDetailView(slug: string): ServiceDetailView | undefined {
+  const canonical = getServiceBySlug(slug)
+  if (!canonical?.detail)
+    return undefined
+  return toServiceDetailView({
+    service: { ...canonical, detail: canonical.detail },
+    office: getOfficeForService(canonical),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Office View — /offices/<slug>
+// ---------------------------------------------------------------------------
+
+export interface OfficeServiceCard {
+  name: string
+  link?: string
+}
+
+export interface OfficeView {
+  office: Office
+  groupName: string
+  services: OfficeServiceCard[]
+  mapsUrl: string
+}
+
+export interface OfficeRecords {
+  office: Office
+  group?: OfficeGroup
+  services: ServiceItem[]
+}
+
+/**
+ * Pure shaper for the /offices/<slug> page.
+ *
+ * Services this Office provides (via `providedBy`) link to their own
+ * /service-details page ONLY when they carry a `detail` block; catalog-only
+ * Services render as a plain, non-clickable card. `office.additionalServices`
+ * are office-only offerings (not Service records yet, no page) appended as plain
+ * cards. The whole list is deduped by name, so a graduated service never appears
+ * twice and two provided Services with the same title collapse to one.
+ */
+export function toOfficeView(records: OfficeRecords): OfficeView {
+  const { office, group, services } = records
+  const seen = new Set<string>()
+  const cards: OfficeServiceCard[] = []
+
+  for (const service of services) {
+    if (service.providedBy !== office.id || service.hidden)
+      continue
+    if (seen.has(service.title))
+      continue
+    seen.add(service.title)
+    cards.push({
+      name: service.title,
+      link: service.detail ? `/service-details/${service.id}` : undefined,
+    })
+  }
+
+  for (const name of office.additionalServices ?? []) {
+    if (seen.has(name))
+      continue
+    seen.add(name)
+    cards.push({ name, link: undefined })
+  }
+
+  return {
+    office,
+    groupName: group?.name ?? '',
+    services: cards,
+    // No geo data on the Office schema — link to Google Maps by address.
+    mapsUrl: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(office.location ?? office.name)}`,
+  }
+}
+
+/**
+ * Bound facade: resolve an Office slug into its OfficeView. Matches on the
+ * Office `id` directly (own /offices/<id> namespace, #207). Returns undefined
+ * for unknown/hidden Offices so the page can throw a 404.
+ */
+export function officeView(slug: string): OfficeView | undefined {
+  const office = getOfficeBySlug(slug)
+  if (!office)
+    return undefined
+  return toOfficeView({
+    office,
+    group: getOfficeGroupBySlug(office.groupId),
+    services: getAllServices(),
+  })
+}


### PR DESCRIPTION
## Summary

Page resolution — turning a slug into what a page renders — lived inline and untested in three pages' `<script setup>`. The risky logic (name-based service dedupe, detail/office merge, catalog-only link suppression) was unreachable by a test without rendering the page.

This introduces the **View resolver seam** (ADR-0002): `app/utils/pageViews.ts`. Each route gets a **bound facade** that does the `configHelper` lookups and delegates to a **pure, IO-free shaper** that holds all mapping. The three pages become render-only: one facade call + a 404 guard.

- `categoryView(slug) → toCategoryView(records)`
- `serviceDetailView(slug) → toServiceDetailView(records)`
- `officeView(slug) → toOfficeView(records)`

Boundary rule (ADR-0002): View shaping moved into `pageViews` (`getServiceOfficeCard` logic + office-card synthesis, now `officeContactCard`); domain reads stayed in `configHelper` (`getOfficesForCategory`, `getOfficeForService`). `getOfficeDetailBySlug` is dropped — `serviceDetailView` resolves Service detail only (the legacy office URL is 301'd by #216, already merged into base).

## AC coverage

- **Three facades + three pure shapers + `CategoryView`/`ServiceDetailView`/`OfficeView` types** — `app/utils/pageViews.ts`.
- **Pages are render-only (one facade call + 404 guard, no mapping/dedupe/merge)** — `app/pages/services/[category].vue`, `app/pages/service-details/[slug].vue`, `app/pages/offices/[slug].vue`.
- **`getServiceOfficeCard` + office-card synthesis moved into shapers; `getOfficesForCategory` stays** — removed from `configHelper.ts`; `officeContactCard` + `toServiceDetailView` in `pageViews.ts`.
- **`serviceDetailView` is Service-detail-only (no `getOfficeDetailBySlug` fallback)** — `getOfficeDetailBySlug` removed; facade returns `undefined` for a slug without a Service `detail`. Test: `serviceDetailView('civil-registry')` → `undefined`.
- **Unit tests per shaper** (`app/utils/pageViews.test.ts`):
  - same-title dedupe → one: `toOfficeView` "dedupes two provided Services with the same title to one"
  - catalog-only → no link: `toCategoryView` "suppresses the link…" and `toOfficeView` "gives a catalog-only provided Service no link"
  - `providedBy` → resolved Office card: `toServiceDetailView` "resolves the Office card from the providing Office"
- **Behavior-equivalent rendering** — shapers reproduce the exact field mapping; facade smoke tests assert real-config resolution against `configHelper`.

## Quality gate

- `pnpm validate` — pass
- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm test` — 167 passed (9 files)
- `pnpm build` — pass (`NUXT_SITE_URL` set, as the sitemap prerender requires; CI does not build)

Closes #217