### PR TITLE
docs(199): pin Office=institutional Department model + ADR-0003

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,8 +13,16 @@ The rich content of a Service — requirements, process steps, FAQs, fees, offic
 _Avoid_: Service page, detail entity
 
 **Office**:
-A government body that provides Services (e.g. Civil Registry Office). A first-class entity, **not** a kind of Service. A Service is delivered by exactly one Office; an Office provides many Services.
-_Avoid_: Department (unless distinct), bureau
+An independent, top-level LGU organization that delivers Services (e.g. City Civil Registry, City Treasurer's Office). A first-class entity, **not** a kind of Service. A Service is delivered by exactly one Office; an Office provides many Services. "Office" here is the **institutional** sense from RA 7160 — the bureau and the charge it exercises, named in statute as "the Office of the City \_\_\_" — **synonymous with Department**. It is **not** the physical room the org occupies (that is the `location` attribute). Headed by an **Official** (its Department Head).
+_Avoid_: Department (the synonym — pick one canonical term), bureau, "office" meaning a place
+
+**Official**:
+A person in government, held in `officials.json`. Three roles: **executive** (Mayor, Vice Mayor), **legislative** (Councilors, Liga/SK presidents), and **Department Head** — an Official who heads exactly one **Office** (references it by id). An Official is a person, **never** an organization; a Department Head's office identity, contact, and description live on the **Office**, not duplicated on the person.
+_Avoid_: department (the org), modeling a head as a name string on the Office
+
+**Division** _(future — no data yet)_:
+A subordinate subunit **within** an Office/Department (e.g. the Appraisal Division under the City Assessor), headed by a **Division Chief** (an Official). Strictly below an Office, never a synonym for it. Not modeled today; an Office carries an optional `parentId` so Divisions can attach later without rework.
+_Avoid_: Office, Department (a Division is neither — it is contained by one)
 
 **Category**:
 A grouping used to organize **Services** for browsing by task — answers "what do I want to do" (e.g. "Certificates", "Business"). Applies to Services only, never Offices.
@@ -31,7 +39,10 @@ _Avoid_: DTO, model, ViewModel, page
 ## Relationships
 
 - **Service → providedBy → Office** (many-to-one)
+- **Official → heads → Office** (a Department Head heads one Office; an Office has at most one head)
 - **Category groups Services** (one-to-many) — by task
 - **Office Group groups Offices** (one-to-many) — by function
+- **Office → parentId → Office** (future: a Division references its parent Office; unused today)
 - A Service's Category is independent of its Office's Office Group
+- An Official is a person; an Office is an organization — the head relationship links the two, never merges them
 - **A View projects canonical records for one route** — built by a resolver, consumed by exactly one page

--- a/docs/adr/0003-office-is-the-institutional-department.md
+++ b/docs/adr/0003-office-is-the-institutional-department.md
@@ -1,0 +1,31 @@
+# Office is the institutional Department; heads are Officials
+
+`#199` asks how `officials.departments[]` (rendered on the Government page as "Department Heads & Key Offices") relates to the canonical **Office** entity (`offices.json`, ADR-0001/#185/#196). The two model the same real-world thing twice: a department's id, name, description, phone, and icon live in both files and have already drifted (e.g. `civil-registry`'s description differs between them). The only data a department adds is the **head** (a person) and `abbreviation`. The Government section, despite its title, renders office-shaped fields (`department`, `description`, `phone`, `email`) and never prints the head — so the head is dead data and the contact block is a drifting duplicate.
+
+Resolving this required pinning what "Office" means, because the term collided: the codebase uses `Office` for the service-providing organization, while "office" colloquially means the room a department occupies.
+
+## Decision
+
+**The canonical entity stays `Office` in code, and `Office` denotes the institutional organization — synonymous with "Department."** Under RA 7160 (Local Government Code of 1991) an LGU is structured as appointive **offices**, each named "the Office of the City \_\_\_" and headed by an appointive official; "Office" there is the institutional sense (a bureau and the charge it exercises, as in "Office of the President"), not a place. So naming the entity `Office` is statutorily correct, and **Department** is the avoidable synonym.
+
+Consequences for the model (recorded in CONTEXT.md):
+
+- **Head = Official, not a scalar.** A Department Head is an `Official` (person) that references the one Office it heads. `officials.departments[]` splits: the person becomes an Official; the organization is the existing Office record. `officials.json` ends up holding only people.
+- **Head presence marks a City-Hall department.** The Government section renders Offices that have a head; `barangay-hall`/`police-station` (no head) are excluded for free — no new flag needed.
+- **One relationship direction.** `Service.providedBy → Office` is canonical; `departments[].services` (Office → one Category) is dead and lossy → removed.
+- **Office (physical place)** = the `location` attribute, never promoted to an entity.
+- **Division / Division Chief** (sub-units below an Office) are out of scope — no data; an Office carries an optional `parentId` so Divisions can attach later.
+- **`officeGroups` is editorial, not source-derived.** The Las Piñas directory lists offices flat with no functional grouping; the `Frontline Services / Administration` split was authored in #185/#196 with no `sourceUrl`. Functional grouping is conventional LGU practice (cf. Quezon City's clusters), but each city defines its own and Las Piñas publishes none. The grouping is kept as a navigation aid and flagged unverified/editorial (ties to the deferred `dataStatus` flag); only `frontline-services` has an external anchor (RA 11032 "frontline service").
+
+## Considered Options
+
+- **Rename `Office` → `Department` everywhere** (`offices.json` → `departments.json`, `OfficeGroup` → `DepartmentGroup`, rewrite ADR-0001/0002). Ontologically purest, but re-churns three freshly-merged PRs (#202/#211/#222) for zero behavior change, and "Office" is in fact the statutory institutional term — so the rename buys little. Rejected.
+- **`Office.head?: string` scalar.** Simplest join, but models a person as a field on an organization, contradicting the people/organization split and RA 7160's framing of the head as an appointed official. Rejected.
+- **Keep both files, link by id.** Lowest migration, but leaves two write surfaces and the exact drift #199 exists to kill. Rejected.
+
+## Consequences
+
+- `officials.json` narrows to people (executive, legislative, Department Heads); office identity/contact/description has one home (`offices.json`).
+- The Government "Department Heads & Key Offices" section reads Offices (grouped by `OfficeGroup`) and joins each head Official — no duplicate JSON, drift closed.
+- A dept→Office id map is required: of 14 departments, only 3 (`civil-registry`, `cswdo`, `cdrrmo`) currently share an id with their Office. `bpls` (Business Permits & Licensing) has no Office and needs one created.
+- `dataStatus`/editorial markup on `officeGroups` is the truthful encoding of an unsourceable grouping; re-sourcing is a separate data-audit item, not part of #199.


### PR DESCRIPTION
Records the design decision for #199 (unify `officials.departments` with the canonical Office entity) before any code lands. Docs only — no behavior change.

## What
- **ADR-0003** — `Office` is the institutional Department (RA 7160 sense), kept under the code name `Office` (no rename). A Department Head is an `Official` referencing one Office, not a scalar. `officeGroups` is editorial/unverified. Includes the rejected options (full rename, scalar head, two-file link) and why.
- **CONTEXT.md glossary** — adds `Official` (people axis incl. Department Heads) and `Division` (future, no data); rewrites `Office` to the institutional-org definition and adds the `heads` / `parentId` relationships.

## Why
`officials.departments[]` and `offices.json` model the same City Hall office twice and have already drifted (e.g. `civil-registry`'s description differs between the two files). Resolving #199 required pinning what "Office" means — the term collided (institutional org vs physical room). RA 7160 settles it: an LGU is structured as appointive "Offices of the City ___", the institutional sense, synonymous with Department. See ADR-0003 for the full reasoning.

## Scope
Decision + glossary only. The implementation checklist (data migration, schema, page rewrite, validation, tests) is posted on #199 and will follow in a separate PR that builds on this.

Refs #199
