### PR TITLE
docs(198): responsible-body tiers (Office/Barangay/Agency) + ADR-0004

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,7 +5,7 @@ Community-driven LGU portal for Las Piñas City. Surfaces government services, o
 ## Language
 
 **Service**:
-An action a resident performs through the LGU (e.g. "Get Birth Certificate", "Renew Business Permit"). Delivered by an **Office**. One canonical record per Service, carrying its **Service Detail** as optional fields.
+An action a resident performs through the LGU (e.g. "Get Birth Certificate", "Renew Business Permit"). Delivered by a **responsible body** — usually a city **Office**, but some Services are delivered by a **Barangay** (lower LGU tier) or an **Agency** (national office in the city). One canonical record per Service, carrying its **Service Detail** as optional fields.
 _Avoid_: Transaction, request
 
 **Service Detail**:
@@ -13,8 +13,8 @@ The rich content of a Service — requirements, process steps, FAQs, fees, offic
 _Avoid_: Service page, detail entity
 
 **Office**:
-An independent, top-level LGU organization that delivers Services (e.g. City Civil Registry, City Treasurer's Office). A first-class entity, **not** a kind of Service. A Service is delivered by exactly one Office; an Office provides many Services. "Office" here is the **institutional** sense from RA 7160 — the bureau and the charge it exercises, named in statute as "the Office of the City \_\_\_" — **synonymous with Department**. It is **not** the physical room the org occupies (that is the `location` attribute). Headed by an **Official** (its Department Head).
-_Avoid_: Department (the synonym — pick one canonical term), bureau, "office" meaning a place
+An independent, top-level LGU organization that delivers Services (e.g. City Civil Registry, City Treasurer's Office). A first-class entity, **not** a kind of Service. A Service is delivered by exactly one Office; an Office provides many Services. "Office" here is the **institutional** sense from RA 7160 — the bureau and the charge it exercises, named in statute as "the Office of the City \_\_\_" — **synonymous with Department**. It is **not** the physical room the org occupies (that is the `location` attribute). Headed by an **Official** (its Department Head). A **city department only** — a **Barangay** (lower LGU tier) and an **Agency** (national office in the city) are *not* Offices, even though residents transact at them.
+_Avoid_: Department (the synonym — pick one canonical term), bureau, "office" meaning a place, applying it to a Barangay or national Agency
 
 **Official**:
 A person in government, held in `officials.json`. Three roles: **executive** (Mayor, Vice Mayor), **legislative** (Councilors, Liga/SK presidents), and **Department Head** — an Official who heads exactly one **Office** (references it by id). An Official is a person, **never** an organization; a Department Head's office identity, contact, and description live on the **Office**, not duplicated on the person.
@@ -23,6 +23,14 @@ _Avoid_: department (the org), modeling a head as a name string on the Office
 **Division** _(future — no data yet)_:
 A subordinate subunit **within** an Office/Department (e.g. the Appraisal Division under the City Assessor), headed by a **Division Chief** (an Official). Strictly below an Office, never a synonym for it. Not modeled today; an Office carries an optional `parentId` so Divisions can attach later without rework.
 _Avoid_: Office, Department (a Division is neither — it is contained by one)
+
+**Barangay**:
+The smallest LGU tier — a local district that is its **own** local government, headed by a **Punong Barangay** (Barangay Captain, "Kap."). Las Piñas has 20, held in `subdivisions.json` (each `{ name, leader, phone }`). A Barangay is **not** a city **Office**, so Services delivered "at your Barangay" (e.g. Barangay Clearance, Barangay ID) point at the **Barangay directory**, never at a single Office. `subdivision` is the template-generic config key/label for this concept; the canonical Las Piñas term is **Barangay**.
+_Avoid_: subdivision (in PH means a private housing development — actively misleading; keep it only as the template config label), district, village
+
+**Agency**:
+A **national** government office physically present in the city that residents transact with (e.g. the PNP station for Police Clearance; later BFP, NBI, BJMP, Prosecutor). Held in `agencies.json`. Office-shaped — name, location, contact, the Services it backs — but **not** a city **Office**: it belongs to the national government, not the LGU, so it lives outside `offices.json` and `OfficeGroup`.
+_Avoid_: Office (it is not a city department), bureau, hotline (a phone number is one attribute, not the Agency)
 
 **Category**:
 A grouping used to organize **Services** for browsing by task — answers "what do I want to do" (e.g. "Certificates", "Business"). Applies to Services only, never Offices.
@@ -38,7 +46,10 @@ _Avoid_: DTO, model, ViewModel, page
 
 ## Relationships
 
-- **Service → providedBy → Office** (many-to-one)
+- **Service → providedBy → Office** (city department; many-to-one)
+- **Service → providedByAgency → Agency** (national office; optional, single ref)
+- **Service → providedByBarangay → Barangay directory** (the resident's own Barangay; a directory pointer, not a single ref)
+- A Service's **responsible body** is exactly one tier: a city **Office**, an **Agency**, or the **Barangay** directory
 - **Official → heads → Office** (a Department Head heads one Office; an Office has at most one head)
 - **Category groups Services** (one-to-many) — by task
 - **Office Group groups Offices** (one-to-many) — by function

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,7 +13,7 @@ The rich content of a Service — requirements, process steps, FAQs, fees, offic
 _Avoid_: Service page, detail entity
 
 **Office**:
-An independent, top-level LGU organization that delivers Services (e.g. City Civil Registry, City Treasurer's Office). A first-class entity, **not** a kind of Service. A Service is delivered by exactly one Office; an Office provides many Services. "Office" here is the **institutional** sense from RA 7160 — the bureau and the charge it exercises, named in statute as "the Office of the City \_\_\_" — **synonymous with Department**. It is **not** the physical room the org occupies (that is the `location` attribute). Headed by an **Official** (its Department Head). A **city department only** — a **Barangay** (lower LGU tier) and an **Agency** (national office in the city) are *not* Offices, even though residents transact at them.
+An independent, top-level LGU organization that delivers Services (e.g. City Civil Registry, City Treasurer's Office). A first-class entity, **not** a kind of Service. A Service delivered by an Office is delivered by exactly one; an Office provides many Services. "Office" here is the **institutional** sense from RA 7160 — the bureau and the charge it exercises, named in statute as "the Office of the City \_\_\_" — **synonymous with Department**. It is **not** the physical room the org occupies (that is the `location` attribute). Headed by an **Official** (its Department Head). A **city department only** — a **Barangay** (lower LGU tier) and an **Agency** (national office in the city) are _not_ Offices, even though residents transact at them.
 _Avoid_: Department (the synonym — pick one canonical term), bureau, "office" meaning a place, applying it to a Barangay or national Agency
 
 **Official**:
@@ -25,7 +25,7 @@ A subordinate subunit **within** an Office/Department (e.g. the Appraisal Divisi
 _Avoid_: Office, Department (a Division is neither — it is contained by one)
 
 **Barangay**:
-The smallest LGU tier — a local district that is its **own** local government, headed by a **Punong Barangay** (Barangay Captain, "Kap."). Las Piñas has 20, held in `subdivisions.json` (each `{ name, leader, phone }`). A Barangay is **not** a city **Office**, so Services delivered "at your Barangay" (e.g. Barangay Clearance, Barangay ID) point at the **Barangay directory**, never at a single Office. `subdivision` is the template-generic config key/label for this concept; the canonical Las Piñas term is **Barangay**.
+The smallest LGU tier — a local district that is its **own** local government, headed by a **Punong Barangay** (Barangay Captain, "Kap."). Las Piñas has 20, held in `subdivisions.json` (each `{ id, name, leader, phone }` — `id` is the slug a `/barangays` route keys on). A Barangay is **not** a city **Office**, so Services delivered "at your Barangay" (e.g. Barangay Clearance, Barangay ID) point at the **Barangay directory**, never at a single Office. `subdivision` is the template-generic config key/label for this concept; the canonical Las Piñas term is **Barangay**.
 _Avoid_: subdivision (in PH means a private housing development — actively misleading; keep it only as the template config label), district, village
 
 **Agency**:
@@ -49,7 +49,7 @@ _Avoid_: DTO, model, ViewModel, page
 - **Service → providedBy → Office** (city department; many-to-one)
 - **Service → providedByAgency → Agency** (national office; optional, single ref)
 - **Service → providedByBarangay → Barangay directory** (the resident's own Barangay; a directory pointer, not a single ref)
-- A Service's **responsible body** is exactly one tier: a city **Office**, an **Agency**, or the **Barangay** directory
+- A Service has **at most one** responsible body — a city **Office**, an **Agency**, or the **Barangay** directory, never two. Having **none** is valid and common: a Service with no first-class provider (e.g. the BPLO business permits) simply sets no tier
 - **Official → heads → Office** (a Department Head heads one Office; an Office has at most one head)
 - **Category groups Services** (one-to-many) — by task
 - **Office Group groups Offices** (one-to-many) — by function

--- a/docs/adr/0004-responsible-body-tiers.md
+++ b/docs/adr/0004-responsible-body-tiers.md
@@ -1,0 +1,30 @@
+# A Service's responsible body has three tiers: Office, Barangay, Agency
+
+`#198` asks us to unhide the `barangay-hall` and `police-station` Offices, which `#196` set `hidden: true` because — unlike City Hall departments — they are not single offices in the City Hall compound. Acting on it surfaced a deeper problem: both were modeled as `Office` records purely to satisfy `Service.providedBy`, but neither is an Office under ADR-0003 (`Office` = a top-level **city** department, RA 7160 sense). They are different *tiers* of government, and forcing them into `offices.json` produced empty stub records, a `hidden` flag, and a self-referential `link`.
+
+## Decision
+
+A Service's **responsible body** is one of **three tiers**, only one of which is an `Office`:
+
+1. **Office** — a city department (RA 7160). `Service.providedBy → officeId`. Unchanged; this is the ADR-0001/0003 spine.
+2. **Barangay** — the smallest LGU tier, its own local government. Las Piñas has 20 in `subdivisions.json`. A barangay-level Service (Barangay Clearance, Barangay ID) is obtained at the resident's **own** barangay, so it points at the **whole directory**, not one record: `Service.providedByBarangay: true` → a "get this at your Barangay Hall" card linking to a `/barangays` page.
+3. **Agency** — a **national** government office physically present in the city (PNP now; BFP, NBI, BJMP, Prosecutor later). Office-shaped (name, location, contact) but national, not LGU. Held in a new `agencies.json`. A Service points at one: `Service.providedByAgency → agencyId`.
+
+The provider relationship is **deliberately asymmetric**: Agency is a **single ref** (one place, like an Office), Barangay is a **directory marker** (no single place — there are 20). They are not unified behind one polymorphic `provider` field because they are not the same shape, and unifying would misrepresent the barangay case as a single provider.
+
+Consequences recorded in CONTEXT.md: new `Barangay` and `Agency` glossary terms; `Office` narrowed to "city department only"; `subdivision` flagged as the template-generic label whose PH colloquial meaning (a private housing development) makes it unfit as the domain term — the domain term is **Barangay**.
+
+## Considered Options
+
+- **Retain both as `Office`** (drop `hidden`, fill data). Fastest, but re-introduces the tier-mixing ADR-0003 just removed: one `Office` card can't represent 20 barangays, and PNP is national, not a city department. Rejected.
+- **One polymorphic `provider: { kind, ref }`** across all tiers. Uniform, but forces the barangay "your own barangay" relationship into a single-ref shape it doesn't have, and churns every existing Service's `providedBy`. Rejected.
+- **Model PNP as a hotline entry.** A police station is a place residents physically visit (clearance, blotter), not a phone number; the hotline is one attribute. Under-models it. Rejected.
+- **Model each of the 20 barangays as a provider record.** Faithful, but duplicates `subdivisions.json` and bloats the provider space for a directory pointer. Rejected.
+
+## Consequences
+
+- New `agencies.json` + `Agency` type + `configHelper` accessor; `Service` gains optional `providedByAgency` and `providedByBarangay`.
+- `barangay-hall` and `police-station` are **removed** from `offices.json` (with them, the `hidden` flag's only remaining users). `barangay-clearance`/`barangay-id` get `providedByBarangay: true`; `police-clearance` gets `providedByAgency: "pnp-laspinas"`.
+- A new `/barangays` page renders the `subdivisions` directory (today it only lives inside `government/index.vue`).
+- The category page's "Responsible Offices" section must resolve all three tiers and widen its heading (it is no longer only Offices).
+- `pnp-laspinas` location/contact must be sourced; mark unverified until confirmed (ties to the deferred `dataStatus` flag).

--- a/docs/adr/0004-responsible-body-tiers.md
+++ b/docs/adr/0004-responsible-body-tiers.md
@@ -1,30 +1,32 @@
 # A Service's responsible body has three tiers: Office, Barangay, Agency
 
-`#198` asks us to unhide the `barangay-hall` and `police-station` Offices, which `#196` set `hidden: true` because — unlike City Hall departments — they are not single offices in the City Hall compound. Acting on it surfaced a deeper problem: both were modeled as `Office` records purely to satisfy `Service.providedBy`, but neither is an Office under ADR-0003 (`Office` = a top-level **city** department, RA 7160 sense). They are different *tiers* of government, and forcing them into `offices.json` produced empty stub records, a `hidden` flag, and a self-referential `link`.
+`#198` asks us to unhide the `barangay-hall` and `police-station` Offices, which `#196` set `hidden: true` because — unlike City Hall departments — they are not single offices in the City Hall compound. Acting on it surfaced a deeper problem: both were modeled as `Office` records purely to satisfy `Service.providedBy`, but neither is an Office under ADR-0003 (`Office` = a top-level **city** department, RA 7160 sense). They are different _tiers_ of government, and forcing them into `offices.json` produced empty stub records, a `hidden` flag, and a self-referential `link`.
 
 ## Decision
 
-A Service's **responsible body** is one of **three tiers**, only one of which is an `Office`:
+A Service has **at most one** responsible body, drawn from **three tiers**, only one of which is an `Office`. Having none is valid — 21 of the 50 Services carry no `providedBy` today (the BPLO business cluster, `cedula`, `scholarship`, …) and stay that way; the rule is _at most one tier_, never _exactly one_:
 
 1. **Office** — a city department (RA 7160). `Service.providedBy → officeId`. Unchanged; this is the ADR-0001/0003 spine.
 2. **Barangay** — the smallest LGU tier, its own local government. Las Piñas has 20 in `subdivisions.json`. A barangay-level Service (Barangay Clearance, Barangay ID) is obtained at the resident's **own** barangay, so it points at the **whole directory**, not one record: `Service.providedByBarangay: true` → a "get this at your Barangay Hall" card linking to a `/barangays` page.
 3. **Agency** — a **national** government office physically present in the city (PNP now; BFP, NBI, BJMP, Prosecutor later). Office-shaped (name, location, contact) but national, not LGU. Held in a new `agencies.json`. A Service points at one: `Service.providedByAgency → agencyId`.
 
-The provider relationship is **deliberately asymmetric**: Agency is a **single ref** (one place, like an Office), Barangay is a **directory marker** (no single place — there are 20). They are not unified behind one polymorphic `provider` field because they are not the same shape, and unifying would misrepresent the barangay case as a single provider.
+The provider relationship is **deliberately asymmetric**: Agency is a **single ref** (one place, like an Office), Barangay is a **directory marker** (no single place — there are 20). They are kept as separate optional fields rather than unified behind one polymorphic `provider` field because unification would rewrite `providedBy` on every existing Service for no behaviour change today. The asymmetry itself is the load-bearing part and must survive whatever encoding is used.
 
 Consequences recorded in CONTEXT.md: new `Barangay` and `Agency` glossary terms; `Office` narrowed to "city department only"; `subdivision` flagged as the template-generic label whose PH colloquial meaning (a private housing development) makes it unfit as the domain term — the domain term is **Barangay**.
 
 ## Considered Options
 
 - **Retain both as `Office`** (drop `hidden`, fill data). Fastest, but re-introduces the tier-mixing ADR-0003 just removed: one `Office` card can't represent 20 barangays, and PNP is national, not a city department. Rejected.
-- **One polymorphic `provider: { kind, ref }`** across all tiers. Uniform, but forces the barangay "your own barangay" relationship into a single-ref shape it doesn't have, and churns every existing Service's `providedBy`. Rejected.
+- **One polymorphic `provider: { kind, ref }`** across all tiers. Uniform, and a discriminated union could model the barangay arm honestly (`{ kind: 'barangay' }` needs no ref) — but it churns every existing Service's `providedBy` for no behaviour change today. Rejected on churn, not on shape; revisit if a fourth tier appears.
+- **Keep both as `Office` records with an `ownership: 'city' | 'national'` discriminator.** Cheapest for the Agency half — one field instead of a parallel file, type, accessor, and detail page — and it would keep PNP out of `OfficeGroup` browsing. Rejected because it re-broadens `Office` to "any org that provides Services" one week after ADR-0003 pinned it to the RA 7160 city-department sense; conceptual integrity of the term outranks the saved file. (Does not address the barangay half at all.)
 - **Model PNP as a hotline entry.** A police station is a place residents physically visit (clearance, blotter), not a phone number; the hotline is one attribute. Under-models it. Rejected.
 - **Model each of the 20 barangays as a provider record.** Faithful, but duplicates `subdivisions.json` and bloats the provider space for a directory pointer. Rejected.
 
 ## Consequences
 
 - New `agencies.json` + `Agency` type + `configHelper` accessor; `Service` gains optional `providedByAgency` and `providedByBarangay`.
-- `barangay-hall` and `police-station` are **removed** from `offices.json` (with them, the `hidden` flag's only remaining users). `barangay-clearance`/`barangay-id` get `providedByBarangay: true`; `police-clearance` gets `providedByAgency: "pnp-laspinas"`.
+- `barangay-hall` and `police-station` are **removed** from `offices.json`. `barangay-clearance`/`barangay-id` get `providedByBarangay: true`; `police-clearance` gets `providedByAgency: "pnp-laspinas"`. The `hidden` flag itself stays in use — `human-resource-management` is still `hidden: true` in `offices.json`, and `categories.json` and `navigation.json` have their own users.
+- `pnpm validate` gains an **at most one** responsible-body rule (`providedBy` / `providedByAgency` / `providedByBarangay` are mutually exclusive; zero is valid). The three-optional-field encoding cannot express this in the type system, so the validator is the only place the invariant is enforced.
 - A new `/barangays` page renders the `subdivisions` directory (today it only lives inside `government/index.vue`).
 - The category page's "Responsible Offices" section must resolve all three tiers and widen its heading (it is no longer only Offices).
 - `pnp-laspinas` location/contact must be sourced; mark unverified until confirmed (ties to the deferred `dataStatus` flag).


### PR DESCRIPTION
Records the design decision for #198 (unhide Barangay Hall + PNP Station) before code lands. Docs only — no behavior change. Follows the same pattern as #224 (ADR-0003).

## What
- **ADR-0004** — a Service's **responsible body** has three tiers, only one of which is an `Office`: **Office** (city dept), **Barangay** (lower LGU tier, reuse `subdivisions`), **Agency** (national office in the city, e.g. PNP). Includes the rejected options (retain-as-Office, polymorphic provider, PNP-as-hotline, 20 barangay records) and the deliberate Agency-ref / Barangay-directory asymmetry.
- **CONTEXT.md** — new `Barangay` and `Agency` glossary terms; `Office` narrowed to "city department only"; `subdivision` flagged as the template-generic label whose PH meaning (a private housing development) makes it unfit as the domain term.

## Why
`barangay-hall` and `police-station` were modeled as `Office` records only to satisfy `Service.providedBy`, but neither is an Office under ADR-0003 (`Office` = top-level **city** department). A barangay is its own lower LGU tier (you transact at *your own* barangay — there are 20); the PNP is a **national** agency. Forcing them into `offices.json` produced empty stub records, the `hidden` flag, and self-referential links. See ADR-0004 for the full reasoning.

## Scope
Decision + glossary only. The implementation checklist (remove the two stub Offices, add `agencies.json` + `Agency` type, repoint the 3 services, build `/barangays`, widen the category-page section, validation/tests) is posted on #198 and follows in a separate PR.

Refs #198
