### PR TITLE
fix(styles): add container side margins at breakpoint widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed page content touching the screen edges at certain viewport widths by setting the container's max-width below each breakpoint
+
 ## [1.2.0] - 2026-05-10
 
 ### Added

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -116,19 +116,19 @@
   margin-left: auto;
 
   @media (min-width: 640px) {
-    max-width: 640px;
+    max-width: 592px;
   }
 
   @media (min-width: 768px) {
-    max-width: 768px;
+    max-width: 720px;
   }
 
   @media (min-width: 1024px) {
-    max-width: 1024px;
+    max-width: 976px;
   }
 
   @media (min-width: 1280px) {
-    max-width: 1280px;
+    max-width: 1232px;
   }
 
   @media (min-width: 1920px) {

--- a/app/assets/css/main.test.ts
+++ b/app/assets/css/main.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+// Regression guard: the container's max-width must stay below each breakpoint
+// so side gutters are visible. Asserts the invariant, not exact px values, so
+// retuning the widths is fine but an edge-to-edge container (the old bug) fails.
+
+// CSS is not a JS module, so read main.css as text and parse it. Resolve from
+// the project root (vitest's cwd) rather than import.meta.url, which Vite serves
+// as a non-file URL under the test runner.
+const css = readFileSync(join(process.cwd(), 'app/assets/css/main.css'), 'utf-8')
+  .replace(/\/\*[\s\S]*?\*\//g, '') // strip comments so commented-out rules don't hide real ones
+
+// Extract (min-width, max-width) pairs from the `@utility container` block.
+// Capture each media block's full body and find `max-width` anywhere inside it,
+// so it stays matched regardless of declaration order.
+function containerBreakpoints(): Array<{ minWidth: number, maxWidth: number }> {
+  const block = css.match(/@utility container\s*\{([\s\S]*?)\n\}/)?.[1] ?? ''
+  const mediaBlocks = block.matchAll(/min-width:\s*(\d+)px\s*\)\s*\{([^{}]*)\}/g)
+  return [...mediaBlocks].flatMap(([, min, body]) => {
+    const max = (body ?? '').match(/max-width:\s*(\d+)px/)?.[1]
+    return max ? [{ minWidth: Number(min), maxWidth: Number(max) }] : []
+  })
+}
+
+describe('container utility — side gutters (max-width < breakpoint)', () => {
+  // Guard against a broken parse silently passing with zero assertions.
+  it('defines max-width for each responsive breakpoint', () => {
+    expect(containerBreakpoints().length).toBeGreaterThan(0)
+  })
+
+  // Core invariant: narrower than the viewport leaves room for a gutter.
+  it.each(containerBreakpoints())(
+    'max-width $maxWidth is less than the $minWidth breakpoint (leaves a gutter)',
+    ({ minWidth, maxWidth }) => {
+      expect(maxWidth).toBeGreaterThan(0)
+      expect(maxWidth).toBeLessThan(minWidth)
+    },
+  )
+})


### PR DESCRIPTION
## Description

Fixed the issue where the container's `max-width` matched its media-query breakpoint (640/768/1024/1280px), which made content sit flush against the screen edges at those exact viewport widths.

Lowered each `max-width` to sit below its breakpoint (592/720/976/1232px) so the container is always narrower than the viewport, giving consistent side margins. Also added a Vitest regression test that asserts each `max-width` stays below its breakpoint, so the bug can't silently return if the widths are retuned later.

No new dependencies are required.

Fixes #116 

## Screenshots 

Captured at the 640px breakpoint.

**Before (content flush against screen edges):**
<img width="1229" height="1140" alt="640-original-bug" src="https://github.com/user-attachments/assets/bd01498b-e024-43d6-af26-c755d2db5ea9" />

**After (visible side gutter):**
<img width="1231" height="1140" alt="640-fix" src="https://github.com/user-attachments/assets/0f51821e-8a9c-4b3c-ab4a-08447182f6da" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Automated: added a regression test checking each container max-width stays below its breakpoint. Reproduce with `pnpm test --run app/assets/css/main.test.ts`.
- [x] Manual: ran `pnpm dev` and used the browser's responsive mode at 640px, 768px, 1024px, and 1280px. Content that used to touch the screen edges now has side margins.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have added my changes to the `Unreleased` section of `CHANGELOG.md`
