### PR TITLE
docs(tracker): priority + effort convention — board bands, no labels

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -13,6 +13,56 @@ Issues and PRDs for this repo live as GitHub issues in `betterlaspinas/betterlas
 
 `gh` infers the repo from `git remote -v` when run inside the clone.
 
+## Priority and effort
+
+Priority lives on the **project board** — [\[BetterLasPiñas\] Development & Roadmap](https://github.com/orgs/betterlaspinas/projects/3) — in its `Priority` field. It does **not** live on labels. Do not add `P0`/`P1`/`priority:*` labels: they would be a second copy of the ranking with no rule for which copy wins, and the divergence fails silently.
+
+Issues are added to the board automatically on creation, so the only manual step is setting the field.
+
+### Bands, not a ranked list
+
+`Priority` is a band, not a position. Everything in a band is equally takeable — pick any unblocked issue in the highest non-empty band.
+
+| Band            | Meaning                                  |
+| --------------- | ---------------------------------------- |
+| 🔴 Must-Have    | Take from here first                     |
+| 🟡 Should-Have  | Next, once Must-Have is empty or blocked |
+| 🟢 Nice-to-Have | Real but unscheduled                     |
+| ❄️ Icebox       | Parked; not a queue                      |
+
+Bands over a strict 1..N order for two reasons: a numbered list goes stale on every new issue, and it cannot absorb concurrent edits — two sessions inserting at position 3 conflict, whereas two sessions adding to a band do not.
+
+**Empty `Priority` means unranked, not lowest.** Most issues are unranked; that is honest rather than a gap to backfill.
+
+### Blocking is separate from priority
+
+Hard dependencies use native GitHub issue dependencies, not priority:
+
+```sh
+gh api -X POST repos/{owner}/{repo}/issues/<N>/dependencies/blocked_by -F issue_id=<blocker .id>
+```
+
+Note this takes the blocker's **`.id`**, not its issue number (`gh api repos/{owner}/{repo}/issues/<N> --jq .id`), and `-F` rather than `-f`.
+
+Priority answers "which of these takeable issues first". Blocking answers "is this takeable at all". A high-priority blocked issue is not takeable — read both.
+
+### Quick wins
+
+Use the board's `Effort` field (`XS (Quick Fix)`, `S (Few hours)`, `M (1-2 days)`, `L (Feature)`). `XS` **is** the quick-win marker — no `quick-win` label.
+
+`Effort` and `good first issue` mean different things and are set independently: `Effort` is how long it takes, `good first issue` is how much repo context it needs. A two-line fix that requires knowing how vitest collection works is `XS` but not a good first issue.
+
+### Who maintains it, and when
+
+The maintainer sets bands; contributors propose changes by commenting on the issue rather than editing the field.
+
+Re-rank on either trigger:
+
+- **🔴 Must-Have empties** — promote from 🟡 Should-Have.
+- **A decision changes the order** — e.g. a [wayfinder map](https://github.com/betterlaspinas/betterlaspinas/issues/235) resolution re-sequences work. Update the bands in the same session that makes the decision, or it will not happen later.
+
+Do not re-rank issue by issue as they are filed. New issues arrive unranked and are banded in batches.
+
 ## When a skill says "publish to the issue tracker"
 
 Create a GitHub issue.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -46,6 +46,12 @@ Note this takes the blocker's **`.id`**, not its issue number (`gh api repos/{ow
 
 Priority answers "which of these takeable issues first". Blocking answers "is this takeable at all". A high-priority blocked issue is not takeable — read both.
 
+### `Status` is not authoritative
+
+`Status` is automated and mostly correct, but it can regress: opening a PR that references an **already-closed** issue flips that issue from `Done` back to `In Progress`, and nothing moves it back. Observed on #72 and #250, both corrected by hand.
+
+Treat `Status` as a hint and the issue's own open/closed state as the truth. Ranking never depends on `Status` — it lives in `Priority`.
+
 ### Quick wins
 
 Use the board's `Effort` field (`XS (Quick Fix)`, `S (Few hours)`, `M (1-2 days)`, `L (Feature)`). `XS` **is** the quick-win marker — no `quick-win` label.
@@ -56,10 +62,11 @@ Use the board's `Effort` field (`XS (Quick Fix)`, `S (Few hours)`, `M (1-2 days)
 
 The maintainer sets bands; contributors propose changes by commenting on the issue rather than editing the field.
 
-Re-rank on either trigger:
+Re-rank on **one** trigger: **a decision changes the order** — e.g. a [wayfinder map](https://github.com/betterlaspinas/betterlaspinas/issues/235) resolution re-sequences work. Update the bands in the same session that makes the decision, or it will not happen later.
 
-- **🔴 Must-Have empties** — promote from 🟡 Should-Have.
-- **A decision changes the order** — e.g. a [wayfinder map](https://github.com/betterlaspinas/betterlaspinas/issues/235) resolution re-sequences work. Update the bands in the same session that makes the decision, or it will not happen later.
+**An empty band is not a trigger.** When 🔴 Must-Have empties, do not promote 🟡 Should-Have into it — just take from Should-Have, which the "highest non-empty band" rule already covers.
+
+Bands are absolute claims about necessity, not queue positions. Promoting on emptiness would make 🔴 Must-Have mean "whatever is currently on top" instead of "required", and would erase the difference between work that is genuinely required and work that merely floated up — so a real Must-Have filed later could no longer outrank it.
 
 Do not re-rank issue by issue as they are filed. New issues arrive unranked and are banded in batches.
 


### PR DESCRIPTION
Resolves the wayfinder decision ticket #241: how priority is expressed durably on this tracker, and how quick wins are marked.

## Decision

**Priority lives on the project board's `Priority` field as bands. No priority labels.**

The board ([\[BetterLasPiñas\] Development & Roadmap](https://github.com/orgs/betterlaspinas/projects/3)) already has `Priority`, `Effort` and `Workstream` single-select fields, and issues are auto-added on creation.

- **Bands, not a strict 1..N order** — a numbered list goes stale on every new issue and cannot absorb concurrent edits (two sessions inserting at position 3 conflict; two sessions adding to a band do not).
- **Bands are absolute claims about necessity, not queue positions.** An empty 🔴 Must-Have is *not* a re-rank trigger — take from the highest non-empty band instead. Promoting on emptiness would redefine Must-Have as "whatever is on top" and erase the difference between genuinely-required work and work that floated up.
- **No `priority:*` labels** — they would be a second copy of the ranking with no reconciliation rule, and the divergence fails silently. The repo already carries 30 labels with known duplicates.
- **`Effort: XS (Quick Fix)` is the quick-win marker** — no new `quick-win` label. `Effort` (how long) and `good first issue` (how much repo context) are set independently, resolving the conflation #241 flagged.
- **Re-rank on one trigger only**: a decision changes the order. New issues arrive unranked and are banded in batches.

Evidence behind "no labels": of 37 open board items, 25 had no `Priority` set and 32 had no `Effort`. The board is fully maintained only on `Status`, which GitHub automates. Manual per-item entry is what decays here — and labels are manual per-item entry too, so mirroring would decay the same way while adding a silent-divergence failure mode.

## Worked example — applied

Banded on the board, transcribed from the hygiene-bar decision in #239 rather than newly ranked. All three are Must-Have on an absolute claim: #239 made them a prerequisite to the entity-model spine, with native blocking edges onto #198 and #199.

| Issue | Priority | Effort |
| --- | --- | --- |
| #230 vitest collects worktrees | 🔴 Must-Have | XS (Quick Fix) |
| #231 `.claude/` not gitignored | 🔴 Must-Have | XS (Quick Fix) |
| #232 pre-commit lints repo-wide | 🔴 Must-Have | S (Few hours) |

Full ranking remains #242's job.

## Also fixed

#72 and #250 were stuck at `In Progress` despite being closed — both corrected to `Done`. Cause: a PR opened *after* the issue closed flips it back off Done, and nothing restores it (#250 closed 16:02, PR #251 opened 22:33; #72 closed 2026-06-19, PR #203 opened 2026-06-22). 2 of 41 closed issues affected. No automation change — disabling the linked-PR workflow would cost the genuine in-progress signal on open issues to prevent a 5% edge case. Documented as a `Status` caveat instead. Diagnosed from behaviour, not config: Projects v2 workflow config isn't exposed in GitHub's public API.

## Notes for reviewer

- Doc-only change. No product code, consistent with the map's plan-only posture.
- Full gate green in this worktree: lint, typecheck, 174 tests / 10 files. (The root checkout's 40 failures are #230 — worktree collection — not this branch.)

## Out of scope

**Label pruning — investigated, no action.** #241 raised it as a sprawl mitigation for labels we are now not adding, so the motivation was already gone. On inspection the premise was also wrong: `app` (48 PRs), `github_actions` (23), `config` (20) and `tests` (6) are all applied automatically by `labeler.yml` and actively used — deleting them would break PR labelling — and `Stale` is owned by `stale.yml`. Only `invalid` and `duplicate` are unused, and both are zero-cost GitHub defaults.

The remaining `testing`/`tests` and `github-actions`/`github_actions` pairs are not duplicates but different populations (manual-on-issues vs labeler-on-PRs; dependabot vs labeler). Consolidating would mean editing `labeler.yml` and dependabot config for mild naming confusion. Judged not worth a ticket (@jmacj).
