### PR TITLE
docs: publish the ranked backlog — board as entry point, plus a severity floor for bugs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,18 +22,27 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 
 ### 🔍 Finding Tasks
 
-We use a [GitHub Project Board](https://github.com/orgs/betterlaspinas/projects/3) to manage and track all active tasks. This is the best place to find something to work on.
+The [GitHub Project Board](https://github.com/orgs/betterlaspinas/projects/3) is the entry point — **not** the issue list. Priority lives in the board's `Priority` field, and that field does not render on `/issues`, so an issue browsed from the issue list carries no ranking.
 
-- **🌟 Start Here**: If you're new to the project, check this tab. It contains issues labeled `good first issue` or `help wanted`.
-- **📋 Triage**: A complete list of all active tasks, grouped by priority.
-- **⚡ Active Sprint**: See what's currently being worked on for the current development cycle.
+**Finding the next thing to work on — one rule:**
+
+> Open the **📋 Triage** view, take any open issue in the **highest non-empty `Priority` band** that has **no open blockers**.
+
+- `Priority` is a **band**, not a position: 🔴 Must-Have → 🟡 Should-Have → 🟢 Nice-to-Have → ❄️ Icebox. Everything inside a band is equally takeable — pick any of them. An empty `Priority` means unranked, not lowest.
+- **Blocked is separate from ranked.** GitHub shows an issue's blockers at the top of its page; a 🔴 Must-Have with an open blocker is not takeable. Read both fields.
+- `Effort` sizes the work: **`XS (Quick Fix)` is the quick-win marker** — start there if you want something small.
+- `good first issue` is about how much repo context is needed, which is a different question from `Effort`. A two-line fix can still need deep context.
+
+Other views: **🌟 Start Here** filters to `good first issue` / `help wanted`; **⚡ Active Sprint** shows what is in flight; **🗓️ Roadmap** shows dated work.
 
 **How to claim a task:**
 
-1.  Browse the **Todo** column in the **🌟 Start Here** or **⚡ Active Sprint** tabs.
-2.  Open the issue you're interested in and read the description.
-3.  **Comment on the issue** stating you'd like to work on it.
+1.  Pick an unblocked issue from the highest non-empty band, as above.
+2.  Open the issue and read the description.
+3.  **Comment on the issue** stating you'd like to work on it. Epics (`Epic: Services > …`) are not claimed whole — comment naming the one Service you want, and a child issue is cut for it.
 4.  Once a maintainer assigns it to you (or gives a thumbs up), you can start!
+
+Maintainers set the bands; propose a change by commenting on the issue rather than editing the field. The full convention, including when re-ranking happens, is in [`docs/agents/issue-tracker.md`](docs/agents/issue-tracker.md).
 
 ### Reporting Bugs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,20 +24,24 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 
 The [GitHub Project Board](https://github.com/orgs/betterlaspinas/projects/3) is the entry point — **not** the issue list. Priority lives in the board's `Priority` field, and that field does not render on `/issues`, so an issue browsed from the issue list carries no ranking.
 
-**Finding the next thing to work on — one rule:**
+**New here? Start with 🌟 Start Here.** It filters the board to issues labeled `good first issue` or `help wanted` — the ones that do not assume deep repo context.
 
-> Open the **📋 Triage** view, take any open issue in the **highest non-empty `Priority` band** that has **no open blockers**.
+**Finding the next thing to work on — one rule, and it is the same in either view:**
+
+> Take any open issue in the **highest non-empty `Priority` band** — 🌟 Start Here and 📋 Triage are both grouped into priority swimlanes — that has **no open blockers**.
+
+Use **🌟 Start Here** if you are an outside or first-time contributor; use **📋 Triage** for the complete backlog. Same bands, same rule; Start Here is just the narrower slice.
 
 - `Priority` is a **band**, not a position: 🔴 Must-Have → 🟡 Should-Have → 🟢 Nice-to-Have → ❄️ Icebox. Everything inside a band is equally takeable — pick any of them. An empty `Priority` means unranked, not lowest.
 - **Blocked is separate from ranked.** GitHub shows an issue's blockers at the top of its page; a 🔴 Must-Have with an open blocker is not takeable. Read both fields.
 - `Effort` sizes the work: **`XS (Quick Fix)` is the quick-win marker** — start there if you want something small.
-- `good first issue` is about how much repo context is needed, which is a different question from `Effort`. A two-line fix can still need deep context.
+- `good first issue` is about how much repo context is needed, which is a different question from `Effort`. A two-line fix can still need deep context, which is why 🌟 Start Here filters on the label and not on `Effort`.
 
-Other views: **🌟 Start Here** filters to `good first issue` / `help wanted`; **⚡ Active Sprint** shows what is in flight; **🗓️ Roadmap** shows dated work.
+The other two views are read-only context: **⚡ Active Sprint** shows what is in flight, **🗓️ Roadmap** shows dated work.
 
 **How to claim a task:**
 
-1.  Pick an unblocked issue from the highest non-empty band, as above.
+1.  Pick an unblocked issue from the highest non-empty band, as above — 🌟 Start Here if you are new.
 2.  Open the issue and read the description.
 3.  **Comment on the issue** stating you'd like to work on it. Epics (`Epic: Services > …`) are not claimed whole — comment naming the one Service you want, and a child issue is cut for it.
 4.  Once a maintainer assigns it to you (or gives a thumbs up), you can start!

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ See [Nuxt Deployment Docs](https://nuxt.com/docs/getting-started/deployment) for
 
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
+Looking for something to work on? The [project board](https://github.com/orgs/betterlaspinas/projects/3) is the ranked backlog — take any open issue in the highest non-empty `Priority` band that has no open blockers. The issue list is not ranked; `Priority` only renders on the board. See [Finding Tasks](CONTRIBUTING.md#-finding-tasks).
+
 ## 📄 License
 
 [MIT License](LICENSE) - See LICENSE file for details.

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ See [Nuxt Deployment Docs](https://nuxt.com/docs/getting-started/deployment) for
 
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
-Looking for something to work on? The [project board](https://github.com/orgs/betterlaspinas/projects/3) is the ranked backlog — take any open issue in the highest non-empty `Priority` band that has no open blockers. The issue list is not ranked; `Priority` only renders on the board. See [Finding Tasks](CONTRIBUTING.md#-finding-tasks).
+Looking for something to work on? The [project board](https://github.com/orgs/betterlaspinas/projects/3) is the ranked backlog — new contributors should start in its **🌟 Start Here** view (`good first issue` / `help wanted`). In any view, take an open issue from the highest non-empty `Priority` band that has no open blockers. The issue list is not ranked; `Priority` only renders on the board. See [Finding Tasks](CONTRIBUTING.md#-finding-tasks).
 
 ## 📄 License
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -52,6 +52,8 @@ Priority answers "which of these takeable issues first". Blocking answers "is th
 
 Treat `Status` as a hint and the issue's own open/closed state as the truth. Ranking never depends on `Status` — it lives in `Priority`.
 
+**A stale `Done` will close a reopened issue when you touch any other field.** The board runs an auto-close workflow on `Status = Done`. Editing `Priority` or `Effort` re-fires it, so an issue that was reopened while its card still said `Done` gets closed again by an unrelated field edit — observed on #62 during #242. Before a batch field edit, fix any `Done` card whose issue is open; if one closes anyway, `gh issue reopen` it and set `Status` afterwards.
+
 ### Quick wins
 
 Use the board's `Effort` field (`XS (Quick Fix)`, `S (Few hours)`, `M (1-2 days)`, `L (Feature)`). `XS` **is** the quick-win marker — no `quick-win` label.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -36,6 +36,20 @@ Bands over a strict 1..N order for two reasons: a numbered list goes stale on ev
 
 Both contributor-facing views — **📋 Triage** (everything) and **🌟 Start Here** (`good first issue` / `help wanted`, where outside contributors land) — are grouped into `Priority` swimlanes, so "take from the highest non-empty band" is the same instruction in either. Keep them that way: a Start Here that is not swimlaned by priority sends first-time contributors in without a ranking.
 
+### Bugs: the severity floor
+
+`bug` is a work type, not a rank — bugs appear in every band. But one floor overrides milestone fit:
+
+> **A confirmed defect on a live, user-facing page is at minimum 🟡 Should-Have.**
+
+A bug may still sit 🟢 Nice-to-Have or lower — but only if it is not user-facing (internal tooling, test infrastructure) or not yet confirmed. Someone has to say which; "low traffic" is not enough on its own.
+
+The floor exists because banding by "what unblocks the current milestone" quietly inverts the site's purpose. Ranking work that blocks *contributors* above work that fixes what *residents* hit is easy to arrive at without anyone deciding it — #230, #245 and #233 are 🔴 because they block us, while the two bugs a resident actually encounters sat below them. On a site whose value is residents finding correct information, that ordering has to be argued for, not defaulted into.
+
+It also compensates for a property of the bands themselves: with "take from the highest non-empty band" as the rule, 🟢 is unreachable while 🟡 holds long-running epics. Deferring a live bug to 🟢 is closer to shelving it than to scheduling it.
+
+Adopted 2026-08-01 amending #239's deferral of #204 (Terms/Privacy table-of-contents rendering the wrong section), which was banded on traffic alone.
+
 ### Blocking is separate from priority
 
 Hard dependencies use native GitHub issue dependencies, not priority:

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -44,7 +44,7 @@ Both contributor-facing views — **📋 Triage** (everything) and **🌟 Start 
 
 A bug may still sit 🟢 Nice-to-Have or lower — but only if it is not user-facing (internal tooling, test infrastructure) or not yet confirmed. Someone has to say which; "low traffic" is not enough on its own.
 
-The floor exists because banding by "what unblocks the current milestone" quietly inverts the site's purpose. Ranking work that blocks *contributors* above work that fixes what *residents* hit is easy to arrive at without anyone deciding it — #230, #245 and #233 are 🔴 because they block us, while the two bugs a resident actually encounters sat below them. On a site whose value is residents finding correct information, that ordering has to be argued for, not defaulted into.
+The floor exists because banding by "what unblocks the current milestone" quietly inverts the site's purpose. Ranking work that blocks _contributors_ above work that fixes what _residents_ hit is easy to arrive at without anyone deciding it — #230, #245 and #233 are 🔴 because they block us, while the two bugs a resident actually encounters sat below them. On a site whose value is residents finding correct information, that ordering has to be argued for, not defaulted into.
 
 It also compensates for a property of the bands themselves: with "take from the highest non-empty band" as the rule, 🟢 is unreachable while 🟡 holds long-running epics. Deferring a live bug to 🟢 is closer to shelving it than to scheduling it.
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -34,6 +34,8 @@ Bands over a strict 1..N order for two reasons: a numbered list goes stale on ev
 
 **Empty `Priority` means unranked, not lowest.** Most issues are unranked; that is honest rather than a gap to backfill.
 
+Both contributor-facing views — **📋 Triage** (everything) and **🌟 Start Here** (`good first issue` / `help wanted`, where outside contributors land) — are grouped into `Priority` swimlanes, so "take from the highest non-empty band" is the same instruction in either. Keep them that way: a Start Here that is not swimlaned by priority sends first-time contributors in without a ranking.
+
 ### Blocking is separate from priority
 
 Hard dependencies use native GitHub issue dependencies, not priority:


### PR DESCRIPTION
Closes #242 — the final ticket on Wayfinder map #235.

## Why

#241 decided priority lives on the [project board](https://github.com/orgs/betterlaspinas/projects/3)'s `Priority` field, not on labels, and accepted one cost: **project fields do not render in the issue list.** A contributor arriving at `/issues` therefore sees no ranking. This PR pays that cost off by making the board the published entry point.

The ranking itself is applied on the board, not in this diff — every open issue now carries a `Priority` band and an `Effort` size.

## Changes

- `CONTRIBUTING.md` — rewrote **Finding Tasks**: **🌟 Start Here** stays the entry point for outside / first-time contributors (`good first issue` / `help wanted`), **📋 Triage** is the full backlog, and because both views are swimlaned by `Priority` the rule is identical in either — *highest non-empty band, no open blockers*. Also documents what bands mean, that blocked ≠ ranked, that `Effort: XS` is the quick-win marker and is independent of `good first issue`, and that Service epics are claimed one Service at a time (#238).
- `README.md` — one line under Contributing pointing at the board, Start Here, and the rule.
- `docs/agents/issue-tracker.md` — three additions:
  - **The severity floor** (see below).
  - Both contributor-facing views must stay swimlaned by `Priority`.
  - A trap hit during the ranking pass: the board auto-closes on `Status = Done`, and editing **any** other field re-fires it, so a reopened issue whose card still said `Done` gets closed by an unrelated `Priority` edit (happened to #62; reopened).

## The severity floor

> **A confirmed defect on a live, user-facing page is at minimum 🟡 Should-Have.**

Raised by @jmacj asking how `bug` relates to the bands. It didn't — and the ranking pass had quietly produced an inversion because of it: the three 🔴 bugs (#230, #245, #233) are 🔴 because they block *contributors*, while the two bugs a resident actually hits (#60, #204) were the lowest-ranked bugs on the board. Nobody decided that; it fell out of banding on milestone fit.

Compounding it, 🟢 is unreachable in practice — "take from the highest non-empty band" means nothing below 🟡 gets touched while 🟡 holds ten long-running Service epics. So #239's deferral of #204 to 🟢 shelved it rather than scheduling it, for an `XS` defect that renders the wrong section on /terms and /privacy.

Adopted as a rule rather than a one-off exception, so it applies to the next bug filed. **#204 moved 🟢 → 🟡** on the board; recorded on #204, on #239 (whose verdict it amends), and on #242. #234 was checked against the floor and deliberately left at 🟢 — three of its four items are commented-out markup, invisible to residents.

Final bug distribution: 🔴 #230, #245, #233 · 🟡 #60, #204 · 🟢 none.

## Notes for reviewer

- No CHANGELOG entry — matches #252, the sibling docs-only PR. The changelog is user-facing; contributor docs are not.
- Board view names were verified against the project's actual views (📋 Triage, 🌟 Start Here, ⚡ Active Sprint, 🗓️ Roadmap).
- `pnpm exec eslint` clean on all three files. Full `pnpm test` is still red from #230 (vitest collects `.claude/worktrees/**`), unrelated to this diff.