### PR TITLE
docs(agents): give backlog fog a durable home and graduate the blocking items

### DIFF
--- a/app/utils/configHelper.ts
+++ b/app/utils/configHelper.ts
@@ -1,3 +1,7 @@
+// Open design question on this file: splitting it into `serviceCatalog` (deep) +
+// `configRegistry` (thin cast-getters). Not yet sharp enough to ticket — see
+// `docs/agents/backlog-fog.md` before growing the interface further.
+
 import type {
   BudgetConfig,
   CategoriesConfig,

--- a/docs/agents/backlog-fog.md
+++ b/docs/agents/backlog-fog.md
@@ -1,0 +1,57 @@
+# Backlog fog
+
+**Fog** is work that is known to be coming but is not yet sharp enough to ticket. This file is where it lives.
+
+It is a **reference, not a queue.** Nothing waits here for someone to remember to check it. Each entry names the moment a reader's eyes land on it without anyone having to look — a file they open, or an external event that happens on its own. An entry that cannot name that moment does not belong here: it is either a ticket (file it) or not worth recording.
+
+Anything that **blocks** other work is not fog. It goes on the [project board](https://github.com/orgs/betterlaspinas/projects/3) as a real issue with a native blocking edge, where tracking already exists.
+
+## Entry shape
+
+Every entry carries four things. Missing any one of them means the entry is misfiled.
+
+| Field                   | What it answers                                            |
+| ----------------------- | ---------------------------------------------------------- |
+| **Trigger**             | What event makes this worth revisiting                     |
+| **Clearing act**        | What kind of work resolves it — a decision, a fact, a feel |
+| **Exit artifact**       | What this becomes when cleared                             |
+| **Surfacing mechanism** | How a reader arrives here without remembering to           |
+
+The clearing act maps onto the tracker's existing wayfinder vocabulary: `wayfinder:grilling` for a decision, `wayfinder:research` for an unknown fact, `wayfinder:prototype` for an unknown feel.
+
+## Entries
+
+### `configHelper` split into `serviceCatalog` + `configRegistry`
+
+`app/utils/configHelper.ts` is a 661-line, 44-export interface fronting two unrelated jobs: reading canonical Service/Office data, and thin cast-getters over the rest of the config. Splitting it sharpens [ADR-0002](../adr/0002-view-resolver-seam.md)'s seam rather than relitigating it.
+
+The open question is **where the seam falls** — which exports belong to which side, and whether the registry half is a seam at all or just leftovers. That is a design call, not a typing job, which is why this is fog and [#256](https://github.com/betterlaspinas/betterlaspinas/issues/256) (the sibling `useLanguage` extraction, surfaced by the same review) is not.
+
+Deliberately not done during the Service content push: this is the seam all ten content epics touch, so refactoring it mid-push buys constant conflict for no user-visible gain.
+
+- **Trigger** — the ten Service content epics (#62–#70, #244) close, **or** an epic's PR is blocked on a `configHelper` change.
+- **Clearing act** — a design pass (`/design-an-interface` or `/codebase-design`) on where the seam falls.
+- **Exit artifact** — a refactor ticket with the seam already decided; likely expand–contract given the call-site fan-out.
+- **Surfacing mechanism** — pointer comment at the top of `app/utils/configHelper.ts`. Anyone opening the file to work on it lands here.
+
+### Post-#84 E2E coverage plan
+
+Which flows earn an E2E test once Playwright infrastructure exists. [#239](https://github.com/betterlaspinas/betterlaspinas/issues/239) ruled [#84](https://github.com/betterlaspinas/betterlaspinas/issues/84) out of this milestone, so specifying coverage now means planning against infrastructure that does not exist.
+
+- **Trigger** — one of #239's named pull-back triggers fires: a route or render regression reaches production, **or** the #63–#70 content epics start changing page templates rather than only data.
+- **Clearing act** — a decision, once there is something to decide against.
+- **Exit artifact** — a coverage-plan ticket, filed alongside #84 rather than before it.
+- **Surfacing mechanism** — the trigger events are self-announcing: a production regression is noticed, and a template change shows up in an epic's diff.
+
+### `Division` entity
+
+`CONTEXT.md` reserves the concept and `Office.parentId` already exists for it, but there is no data and no demand. Correct as-is — the reservation is the whole design.
+
+- **Trigger** — a real Division appears in source data.
+- **Clearing act** — none in advance. Modelling an entity with no instances is how you get the wrong model.
+- **Exit artifact** — nothing, unless the trigger fires.
+- **Surfacing mechanism** — the event itself. Whoever hits a real Division reads this and learns the question was already considered, rather than re-deriving it.
+
+## Provenance
+
+These entries came from the _Not yet specified_ section of [#235](https://github.com/betterlaspinas/betterlaspinas/issues/235), the wayfinder map that ranked this backlog. That section had no home once the map closed: it was absent from the board and from `docs/`, and its revisit triggers had no reader. Three of the map's six fog items graduated to real issues instead — [#254](https://github.com/betterlaspinas/betterlaspinas/issues/254) (third-party embed and consent posture), [#255](https://github.com/betterlaspinas/betterlaspinas/issues/255) (Category assignment rule, absorbing the `online` / `government` question), and [#256](https://github.com/betterlaspinas/betterlaspinas/issues/256) (`useLanguage` dictionary extraction, which was never fog — only unfiled).

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -88,6 +88,14 @@ Bands are absolute claims about necessity, not queue positions. Promoting on emp
 
 Do not re-rank issue by issue as they are filed. New issues arrive unranked and are banded in batches.
 
+### Work that is not yet a ticket
+
+Work known to be coming but not yet sharp enough to ticket lives in [`backlog-fog.md`](./backlog-fog.md), not on the board — the board holds claimable issues, and an issue nobody can claim rots there.
+
+That file is a reference, not a queue: each entry names how a reader arrives at it on their own, so nothing in it depends on someone remembering to check. Scanning it when a decision re-ranks the backlog is a backstop, not the mechanism.
+
+**Anything that blocks other work is not fog.** It is a real issue with a native blocking edge, however unsharp it feels.
+
 ## When a skill says "publish to the issue tracker"
 
 Create a GitHub issue.


### PR DESCRIPTION
Dispositions the six fog items left unresolved by the wayfinder map [#235](https://github.com/betterlaspinas/betterlaspinas/issues/235).

## The problem

#235's *Not yet specified* section had no home once the map closed. It was absent from the [project board](https://github.com/orgs/betterlaspinas/projects/3) and from `docs/`, and every entry's revisit trigger ("revisit once #245 settles…", "once #223 has shipped one instance") had no reader. A trigger nobody watches does not fire — the fog would have been re-derived from scratch by whoever next tripped on it.

Two of the six were also **latent blockers**, invisible on the dependency graph:

- **#208 was takeable today** with `blocked_by: none`, and would have shipped a second ad-hoc consent gate — making the GA-vs-Facebook inconsistency #223 deliberately left alone into precedent rather than an anomaly.
- **The Category-assignment question was an unrecorded eleventh blocker on all ten Service epics.** #62–#70 and #244 all share `blocked_by: #233, #243, #245`; when those close, all ten become claimable at once with "which Category does a Service belong to, and what does `hidden` mean" still unanswered.

## Disposition

**Blocking work is not fog — it went on the board** (filed via `/to-tickets`, edges native, bands set):

| Issue | What | Band | Edges |
| --- | --- | --- | --- |
| #254 | Sitewide third-party embed + consent posture; does GA come under it | 🟡 / S | `blocked_by` #223 → blocks **#208** |
| #255 | Rule for which Category a Service belongs to; absorbs `online`/`government` | 🔴 / M | `blocked_by` #245 → blocks **#62–#70, #244** |
| #256 | `useLanguage` dictionary extraction | 🟢 / S | none |

#255 is 🔴 for the same reason #245/#243/#233 were promoted: hard blocker of all ten epics. #256 was never fog — no open question, just an unfiled ticket; mislabelling it is what makes a fog doc rot.

**The remaining three live in `docs/agents/backlog-fog.md`** — `configHelper` seam, post-#84 E2E plan, `Division`.

## Why a doc needs no tracking

The file is a **reference, not a queue.** Every entry carries trigger / clearing act / exit artifact / **surfacing mechanism**, and that last field is the load-bearing one: it names how a reader arrives without anyone remembering to look. `configHelper` gets a pointer comment on the file itself, so it fires when someone opens it to work on it. `Division` and the E2E plan are event-gated and self-announcing.

An entry that cannot name that moment is misfiled — it is a ticket, or it is not worth recording. That constraint is what stops this file becoming the graveyard #235's body became.

Deliberately **not** another manual discipline: an earlier draft hooked fog review to the re-rank trigger, but #241 already demonstrated that manual per-item upkeep decays here (25 of 37 board items had no `Priority`). Scanning the file on a re-rank is documented as a backstop only.

## Verification

- Blocking edges re-read after writing, both directions: `blocked_by` on each of #254/#255/#208/#62–#70/#244, and `blocking` from #255 (ten epics) and #254 (#208).
- Board fields confirmed by re-reading the items; all three cards were `Status = Todo`, so the stale-`Done` auto-close trap did not apply.
- Gate green: `pnpm validate` ✔, `pnpm lint` clean, `pnpm test --run` 174 passed / 10 files, `nuxi typecheck` clean (pre-commit hook).

## Notes for reviewer

- **The one source touch** is a three-line comment atop `app/utils/configHelper.ts`. #235's posture is plan-only, so this was confirmed with @jmacj before writing — without it that fog entry has no surfacing mechanism and the rot returns.
- **No CHANGELOG entry.** This is internal process documentation with no user-facing behaviour change.
- **#235 stays closed.** It holds the decision trail; graduated fog became ordinary board issues rather than reopening the map to contain them. Disposition is cross-linked as a comment there.
- **The #254 → #208 edge is a judgment call.** It chains #208 behind #223. If #208 is split so the Maps widget lands separately, move the edge to that child rather than dropping it — the intent is that no second consent gate ships before the rule exists.
