### PR TITLE
fix(test): exclude .claude/ from vitest + gitignore + document scratch-file convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,14 @@ lerna-debug.log*
 # Test coverage
 coverage
 coverage/
+
+# Agent worktrees + tool state (machine-local; not part of the repo)
+.claude/
+
+# Agent scratch documents (never meant to be committed — see CONTRIBUTING.md)
+.scratch/
+research.md
+architecture-review.html
+HANDOFF-*.md
+handoff-*.md
+.antigravitycli/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed page content touching the screen edges at certain viewport widths by setting the container's max-width below each breakpoint
+- Fixed pre-commit going red on any checkout with agent worktrees or root scratch files present: `vitest.config.ts` now excludes `.claude/**`, and `.gitignore` now excludes `.claude/` and common scratch-file patterns so repo-wide `eslint .` no longer trips on them (#230, #231, #232)
+
+### Documentation
+- Documented agent worktree pruning and the scratch-file convention in `CONTRIBUTING.md` (#231)
 
 ## [1.2.0] - 2026-05-10
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,12 @@ pnpm test
 pnpm lint && pnpm typecheck && pnpm test --run
 ```
 
+### Agent Worktrees & Scratch Files
+
+- `.claude/` (agent worktrees, tool state) is gitignored — never commit it, and never rely on a machine-local global gitignore to hide it from another contributor's checkout.
+- **Prune your worktree once its PR merges**: `git worktree remove .claude/worktrees/<branch>` (add `--force` only if you're sure there's nothing uncommitted in it), then delete the now-unused local branch. A stale worktree left behind after merge is just disk clutter — remove it as part of closing out the PR, not later.
+- Agent-generated scratch documents (research notes, handoff notes, one-off HTML reports) do not belong at the repo root — they get picked up by repo-wide tooling (`eslint .`, `vitest`) and fail checks unrelated to your change. Put them in a gitignored `.scratch/` directory, or delete them before committing.
+
 ## 📝 Coding Standards
 
 ### TypeScript

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineVitestConfig } from '@nuxt/test-utils/config'
 export default defineVitestConfig({
   test: {
     environment: 'happy-dom',
-    exclude: ['legacy_backup/**', 'node_modules/**', '.nuxt/**', '.output/**'],
+    exclude: ['legacy_backup/**', 'node_modules/**', '.nuxt/**', '.output/**', '.claude/**', '**/.claude/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'json-summary'],


### PR DESCRIPTION
## Summary

Combined PR per the repo-owner decree on #230 (map #235): #230, #231, and #232 share one root cause — `.claude/` (agent worktrees, tool state) and untracked root scratch files are invisible to repo-level tooling, so every PR was shipping through a red pre-commit. Fixing all three here avoids paying the review/gate tax three times for a combined trivial diff.

- `vitest.config.ts` collected test files from `.claude/worktrees/**`, running foreign checkouts against this repo's `node_modules`/`.nuxt` — full suite went red (40 failures) on any checkout with agent worktrees present.
- `.claude/` was absent from `.gitignore` — only hidden via a machine-local global gitignore, so any other checkout (CI, another contributor) saw every registered worktree.
- Because antfu's ESLint config honours `.gitignore`, the missing entry also meant `eslint .` picked up worktree content and untracked root scratch files (`research.md`, `architecture-review.html`, `HANDOFF-*.md`, `.antigravitycli/`) — unrelated files blocking commits.

## Changes

- `vitest.config.ts`: added `.claude/**` and `**/.claude/**` to `exclude`
- `.gitignore`: added `.claude/` and common agent scratch-file patterns (`.scratch/`, `research.md`, `architecture-review.html`, `HANDOFF-*.md`, `handoff-*.md`, `.antigravitycli/`)
- `CONTRIBUTING.md`: new "Agent Worktrees & Scratch Files" section documenting worktree pruning after merge and the scratch-file convention
- `CHANGELOG.md`: `[Unreleased]` entry, no version cut

## Acceptance criteria

**#230**
- [x] `vitest.config.ts` `exclude` covers `.claude/**`
- [x] `pnpm test --run` is green on this branch **with worktrees present under `.claude/worktrees/`** (11 worktrees present during the run — 10 files / 174 tests passed)
- [x] `pnpm lint`, `pnpm typecheck` pass
- [x] #227 re-verified — already closed as `not_planned`, confirmed duplicate of #230 in the issue's own comment thread. No action taken.

**#231** (repo-shippable slice only — see Notes)
- [x] `.claude/` added to `.gitignore`
- [x] Checked for intentionally-versioned files under `.claude/` before ignoring: `git ls-files .claude/` returns empty, nothing tracked, no un-ignore exception needed
- [x] Documented worktree-pruning convention in `CONTRIBUTING.md`
- [ ] Deletion of the 11 existing stale worktrees — explicitly OUT OF SCOPE (see Notes)

**#232**
- [x] A commit touching only `app/**` is not blocked by the known root scratch-file patterns (gitignored, so `eslint .` no longer walks them)
- [x] The hook still catches lint/type/test regressions in changed code (nothing in the hook itself changed, only exclusion scope)
- [x] Documented in `CONTRIBUTING.md`
- [ ] Scoping pre-commit to staged files (`lint-staged`) — explicitly deferred to #246 per the issue's own comment thread, not this PR's scope

## Notes for reviewer

- **Scope decision**: this PR intentionally covers three issues at once. That's not scope creep — it's a direct instruction from the repo owner in a comment on #230 itself ("Ships as ONE PR covering all three"), made as part of the #235 quality-hygiene-bar decision. Flagged to the team lead before starting; got an explicit go-ahead to combine.
- **#231 worktree deletion is deliberately unmet** in this PR. The 11 worktrees currently under `.claude/worktrees/` are live checkouts — other agent sessions are running inside some of them right now. Running `git worktree remove` on them here would be destructive to concurrent work outside this PR's control. That cleanup is machine-local and left to the maintainer to run when convenient, not something a PR diff can safely do.
- **#232 scope**: the issue's own comment thread already routes the "scope lint to staged files" checkbox to a separate follow-up (#246), leaving "ignore/relocate root scratch artifacts" as this PR's actual deliverable for #232. Did not touch `.husky/pre-commit` itself.
- **Scratch-file pattern list is a known-names allowlist**, not a fully general fix — an arbitrary untracked file with an unmatched name at root can still trip `eslint .`. Full generality is exactly what `lint-staged` (#246) would provide; this PR only removes the specific footguns named in #232's own decision comment.
- `git ls-files .claude/` was checked before ignoring the whole directory, in case something like `.claude/settings.json` was intentionally versioned — it isn't, so no un-ignore exception was needed.

Closes #230
Closes #231
Closes #232