### PR TITLE
fix(repo): anchor agent scratch-file gitignore patterns to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,9 @@ coverage/
 .claude/
 
 # Agent scratch documents (never meant to be committed — see CONTRIBUTING.md)
-.scratch/
-research.md
-architecture-review.html
-HANDOFF-*.md
-handoff-*.md
-.antigravitycli/
+/.scratch/
+/research.md
+/architecture-review.html
+/HANDOFF-*.md
+/handoff-*.md
+/.antigravitycli/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed page content touching the screen edges at certain viewport widths by setting the container's max-width below each breakpoint
 - Fixed pre-commit going red on any checkout with agent worktrees or root scratch files present: `vitest.config.ts` now excludes `.claude/**`, and `.gitignore` now excludes `.claude/` and common scratch-file patterns so repo-wide `eslint .` no longer trips on them (#230, #231, #232)
+- Anchored the agent scratch-file `.gitignore` patterns (`.scratch/`, `research.md`, `architecture-review.html`, `HANDOFF-*.md`, `handoff-*.md`, `.antigravitycli/`) to the repo root with a leading `/`, so they no longer match at any depth — aligning with `CONTRIBUTING.md`'s stated root-only intent (#231, follow-up to #259)
 
 ### Documentation
 - Documented agent worktree pruning and the scratch-file convention in `CONTRIBUTING.md` (#231)


### PR DESCRIPTION
## Summary

Follow-up to #259 (PR #259, review finding on #231). Adds a leading `/` to the agent scratch-file `.gitignore` patterns so they only match at the repo root:

```
/.scratch/
/research.md
/architecture-review.html
/HANDOFF-*.md
/handoff-*.md
/.antigravitycli/
```

Previously these were unanchored and matched at any depth, but `CONTRIBUTING.md` states these files "do not belong at the repo root" — root-only intent. `.claude/` is intentionally left unanchored since it must keep matching at any depth (nested agent worktrees live under `.claude/worktrees/...` at various depths).

## Verification

```
$ git check-ignore -v research.md .scratch/foo architecture-review.html HANDOFF-x.md handoff-x.md .antigravitycli/foo
.gitignore:40:/research.md	research.md
.gitignore:39:/.scratch/	.scratch/foo
.gitignore:41:/architecture-review.html	architecture-review.html
.gitignore:42:/HANDOFF-*.md	HANDOFF-x.md
.gitignore:43:/handoff-*.md	handoff-x.md
.gitignore:44:/.antigravitycli/	.antigravitycli/foo

$ git check-ignore -v docs/research.md
(no match, exit 1 — correctly NOT ignored)

$ git check-ignore -v src/HANDOFF-test.md
(no match, exit 1 — correctly NOT ignored)
```

Confirmed no currently tracked file matches any of these patterns (`git ls-files | grep ...` → none).

## Quality gate

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm test --run` — 174/174 pass

## Refs

Refs #231, follow-up to #259.