### PR TITLE
fix(build): resolve Tailwind CSS entry under Vite 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fixed the production build failing on `[postcss] ENOENT ... open '<root>/tailwindcss'` after Nuxt 4.5.1 (#266) pulled in Vite 8: `app/assets/css/main.css` now imports `tailwindcss/index.css` instead of the bare `tailwindcss` specifier, which Vite 8's bundled postcss-import cannot resolve
 - Fixed page content touching the screen edges at certain viewport widths by setting the container's max-width below each breakpoint
 - Fixed pre-commit going red on any checkout with agent worktrees or root scratch files present: `vitest.config.ts` now excludes `.claude/**`, and `.gitignore` now excludes `.claude/` and common scratch-file patterns so repo-wide `eslint .` no longer trips on them (#230, #231, #232)
 - Anchored the agent scratch-file `.gitignore` patterns (`.scratch/`, `research.md`, `architecture-review.html`, `HANDOFF-*.md`, `handoff-*.md`, `.antigravitycli/`) to the repo root with a leading `/`, so they no longer match at any depth — aligning with `CONTRIBUTING.md`'s stated root-only intent (#231, follow-up to #259)

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,4 +1,9 @@
-@import 'tailwindcss';
+/* Import the explicit `index.css` subpath rather than the bare `tailwindcss`
+   specifier. Vite 8 runs its bundled postcss-import over CSS @import, and that
+   resolver does not honour the "style" export condition — which is the only way
+   Tailwind v4's "." export exposes CSS. The bare specifier therefore falls back
+   to a path lookup and fails with ENOENT on <root>/tailwindcss. */
+@import 'tailwindcss/index.css';
 
 @theme {
   /* Fonts */


### PR DESCRIPTION
## Problem

The production build fails in `vite:css` on the Tailwind import at the top of `app/assets/css/main.css`:

```
[plugin vite:css] /opt/buildhome/repo/app/assets/css/main.css:undefined:NaN
Error: [postcss] ENOENT: no such file or directory, open '/opt/buildhome/repo/tailwindcss'
```

This is on `main`, so it blocks every build — including the checks on #261.

## Root cause

**Reproduced locally on `main` (`aaf1db1`), identical error.** The installed Vite path is `vite@8.2.0_@types+node@26.1.2_esbuild@0.28.1_jiti@2.7.0_terser@5.49.0_yaml@2.9.0` — byte-identical to the failing CI log.

The trigger is #266, which bumped `nuxt` 4.4.8 -> 4.5.1. `@nuxt/vite-builder@4.5.1` requires `vite: ^8.1.5`, so that bump pulled Vite 8 in transitively.

Vite 8 runs its own bundled `postcss-import` over CSS `@import`. That resolver does not honour the `"style"` export condition — which is the only way Tailwind v4's `"."` export exposes CSS:

```jsonc
".": {
  "types":   "./dist/lib.d.mts",
  "style":   "./index.css",   // ← the CSS entry, only reachable via the "style" condition
  "require": "./dist/lib.js",
  "import":  "./dist/lib.mjs"
}
```

With no usable condition, the bare `tailwindcss` specifier falls back to a path lookup relative to the project root — hence `ENOENT` on `<root>/tailwindcss`.

Worth stating plainly: **the package is installed and present.** This is a resolution failure, not a missing dependency, so moving `tailwindcss` out of `devDependencies` would not have fixed it.

## Fix

Import the explicit `tailwindcss/index.css` subpath, which the package exports directly (`"./index.css": "./index.css"`) and `postcss-import` resolves without needing export conditions.

One line. No dependency changes, no config changes, and it remains correct on Vite 7 — so it is safe if the nuxt bump is ever reverted. A comment above the import records why the non-obvious subpath is used, so it does not get "tidied" back to the bare specifier later.

## Alternative considered

Switching from `@tailwindcss/postcss` to `@tailwindcss/vite`, whose Vite plugin intercepts the import before PostCSS ever sees it. That is Tailwind's recommended route for Vite builds and I verified it works on Vite 8 — but it swaps the whole CSS pipeline, drops the `autoprefixer` step currently configured in `nuxt.config.ts`, and adds a dependency. Disproportionate for an unblock. Reasonable as a separate follow-up if you want it.

## Verification

Run against the reproduced failure on `main`:

- `pnpm build` — green (was failing before the change)
- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 174/174 passing
- Pre-commit hook ran lint + typecheck + tests independently — all passed
- Output CSS sanity-checked, not just "build exited 0": `entry.css` is 63k with utilities (`.flex`, `.grid`, `.mx-auto`, `.text-center`) and preflight present, so Tailwind still compiles fully

## Notes for reviewer

- The `.env.example` values were needed locally to get past sitemap prerendering; no `.env` is committed.
- Once this lands, #261's checks should go green on a rebase.